### PR TITLE
Properly flush `HTTP.rb` if not OK

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai (1.0.5)
+    omniai (1.0.6)
       event_stream_parser
       http
       zeitwerk

--- a/lib/omniai/chat.rb
+++ b/lib/omniai/chat.rb
@@ -55,7 +55,7 @@ module OmniAI
     # @raise [ExecutionError]
     def process!
       response = request!
-      raise HTTPError, response unless response.status.ok?
+      raise HTTPError, response.flush unless response.status.ok?
 
       parse!(response:)
     end

--- a/lib/omniai/version.rb
+++ b/lib/omniai/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniAI
-  VERSION = '1.0.5'
+  VERSION = '1.0.6'
 end


### PR DESCRIPTION
This ensures the persistent HTTP.rb connection is useable in bulk.