### PR TITLE
Fix Documentation for `#transcribe` Taking IO or Pathname

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai (1.1.3)
+    omniai (1.1.4)
       event_stream_parser
       http
       zeitwerk

--- a/README.md
+++ b/README.md
@@ -62,19 +62,19 @@ client = OmniAI::OpenAI::Client.new
 
 Clients that support chat (e.g. Anthropic w/ "Claude", Google w/ "Gemini", Mistral w/ "LeChat", OpenAI w/ "ChatGPT", etc) generate completions using the following calls:
 
-#### w/ a Simple Prompt
+#### Completions using Single Message
 
 ```ruby
 completion = client.chat('Tell me a joke.')
 completion.choice.message.content # '...'
 ```
 
-#### w/ a Collection of Messages
+#### Completions using Multiple Messages
 
 ```ruby
 messages = [
   {
-    role: 'system',
+    role: OmniAI::Chat::Role::SYSTEM,
     content: 'You are a helpful assistant with an expertise in geography.',
   },
   'What is the capital of Canada?'
@@ -83,7 +83,7 @@ completion = client.chat(messages, model: '...', temperature: 0.7, format: :json
 completion.choice.message.content  # '...'
 ```
 
-#### Streaming
+#### Completions using Real-Time Streaming
 
 ```ruby
 stream = proc do |chunk|
@@ -96,7 +96,17 @@ client.chat('Tell me a joke.', stream:)
 
 Clients that support chat (e.g. OpenAI w/ "Whisper", etc) convert recordings to text via the following calls:
 
+#### Transcriptions with Path
+
 ```ruby
-transcription = client.transcribe(file.path)
+transcription = client.transcribe("example.ogg")
+transcription.text # '...'
+```
+
+#### Transcriptions with Files
+
+```ruby
+file = File.open("example.ogg", "rb")
+transcription = client.transcribe(file)
 transcription.text # '...'
 ```

--- a/lib/omniai/client.rb
+++ b/lib/omniai/client.rb
@@ -48,7 +48,7 @@ module OmniAI
 
     # @raise [OmniAI::Error]
     #
-    # @param file [IO]
+    # @param io [String, Pathname, IO] required
     # @param model [String]
     # @param language [String, nil] optional
     # @param prompt [String, nil] optional
@@ -56,7 +56,7 @@ module OmniAI
     # @param format [Symbol] :text, :srt, :vtt, or :json (default)
     #
     # @return text [OmniAI::Transcribe::Transcription]
-    def transcribe(file, model:, language: nil, prompt: nil, temperature: nil, format: nil)
+    def transcribe(io, model:, language: nil, prompt: nil, temperature: nil, format: nil)
       raise NotImplementedError, "#{self.class.name}#speak undefined"
     end
   end

--- a/lib/omniai/transcribe.rb
+++ b/lib/omniai/transcribe.rb
@@ -96,15 +96,15 @@ module OmniAI
       new(...).process!
     end
 
-    # @param path [String] required
+    # @param io [String, Pathname, IO] required
     # @param client [OmniAI::Client] the client
     # @param model [String] required
     # @param language [String, nil] optional
     # @param prompt [String, nil] optional
     # @param temperature [Float, nil] optional
     # @param format [String, nil] optional
-    def initialize(path, client:, model:, language: nil, prompt: nil, temperature: nil, format: Format::JSON)
-      @path = path
+    def initialize(io, client:, model:, language: nil, prompt: nil, temperature: nil, format: Format::JSON)
+      @io = io
       @model = model
       @language = language
       @prompt = prompt
@@ -128,7 +128,7 @@ module OmniAI
     # @return [Hash]
     def payload
       {
-        file: HTTP::FormData::File.new(@path),
+        file: HTTP::FormData::File.new(@io),
         model: @model,
         language: @language,
         prompt: @prompt,

--- a/lib/omniai/version.rb
+++ b/lib/omniai/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniAI
-  VERSION = '1.1.3'
+  VERSION = '1.1.4'
 end

--- a/spec/omniai/transcribe_spec.rb
+++ b/spec/omniai/transcribe_spec.rb
@@ -17,18 +17,18 @@ class FakeTranscribe < OmniAI::Transcribe
 end
 
 RSpec.describe OmniAI::Transcribe do
-  subject(:transcribe) { described_class.new(path, model:, client:) }
+  subject(:transcribe) { described_class.new(io, model:, client:) }
 
   let(:model) { '...' }
   let(:client) { OmniAI::Client.new(api_key: '...') }
-  let(:path) { Pathname.new(File.dirname(__FILE__)).join('..', 'fixtures', 'file.ogg') }
+  let(:io) { Pathname.new(File.dirname(__FILE__)).join('..', 'fixtures', 'file.ogg') }
 
   describe '#path' do
     it { expect { transcribe.send(:path) }.to raise_error(NotImplementedError) }
   end
 
   describe '.process!' do
-    subject(:process!) { FakeTranscribe.process!(path, client:, model:, format:) }
+    subject(:process!) { FakeTranscribe.process!(io, client:, model:, format:) }
 
     let(:format) { described_class::Format::JSON }
 


### PR DESCRIPTION
This properly documents that IO can be a String / Pathname or IO / File