### PR TITLE
Document Usage with LocalAI and Ollama

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai (1.2.1)
+    omniai (1.2.2)
       event_stream_parser
       http
       zeitwerk

--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ require 'omniai/openai'
 client = OmniAI::OpenAI::Client.new
 ```
 
+#### Usage with LocalAI
+
+LocalAI support is offered through [OmniAI::OpenAI](https://github.com/ksylvest/omniai-openai):
+
+[Usage with LocalAI](https://github.com/ksylvest/omniai-openai#usage-with-localai)
+
+#### Usage with Ollama
+
+Ollama support is offered through [OmniAI::OpenAI](https://github.com/ksylvest/omniai-openai):
+
+[Usage with Ollama](https://github.com/ksylvest/omniai-openai#usage-with-ollama)
+
 ### Chat
 
 Clients that support chat (e.g. Anthropic w/ "Claude", Google w/ "Gemini", Mistral w/ "LeChat", OpenAI w/ "ChatGPT", etc) generate completions using the following calls:

--- a/lib/omniai/client.rb
+++ b/lib/omniai/client.rb
@@ -13,19 +13,28 @@ module OmniAI
   class Client
     class Error < StandardError; end
 
-    attr_accessor :api_key
+    attr_accessor :api_key, :logger, :host
 
-    # @param api_key [String]
-    # @param logger [Logger]
-    def initialize(api_key:, logger: nil)
+    # @param api_key [String] optional
+    # @param host [String] optional - supports for customzing the host of the client (e.g. 'http://localhost:8080')
+    # @param logger [Logger] optional
+    def initialize(api_key: nil, logger: nil, host: nil)
       @api_key = api_key
+      @host = host
       @logger = logger
     end
 
     # @return [String]
     def inspect
-      masked_api_key = "#{api_key[..2]}***" if api_key
-      "#<#{self.class.name} api_key=#{masked_api_key.inspect}>"
+      props = []
+      props << "api_key=#{masked_api_key.inspect}" if @api_key
+      props << "host=#{@host.inspect}" if @host
+      "#<#{self.class.name} #{props.join(' ')}>"
+    end
+
+    # @return [String]
+    def masked_api_key
+      "#{api_key[..2]}***" if api_key
     end
 
     # @return [HTTP::Client]

--- a/lib/omniai/version.rb
+++ b/lib/omniai/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniAI
-  VERSION = '1.2.1'
+  VERSION = '1.2.2'
 end

--- a/spec/omniai/client_spec.rb
+++ b/spec/omniai/client_spec.rb
@@ -1,12 +1,17 @@
 # frozen_string_literal: true
 
 RSpec.describe OmniAI::Client do
-  subject(:client) { described_class.new(api_key:) }
+  subject(:client) { described_class.new(api_key:, host:) }
 
   let(:api_key) { 'abcdef' }
+  let(:host) { 'http://localhost:8080' }
 
   describe '#api_key' do
     it { expect(client.api_key).to eq(api_key) }
+  end
+
+  describe '#host' do
+    it { expect(client.host).to eq(host) }
   end
 
   describe '#connection' do
@@ -18,6 +23,6 @@ RSpec.describe OmniAI::Client do
   end
 
   describe '#inspect' do
-    it { expect(client.inspect).to eq('#<OmniAI::Client api_key="abc***">') }
+    it { expect(client.inspect).to eq('#<OmniAI::Client api_key="abc***" host="http://localhost:8080">') }
   end
 end


### PR DESCRIPTION
Linking to the OpenAI documentation for usage with both through the compatibility layer. This documentation is in support of https://github.com/ksylvest/omniai/issues/21. It also makes it easier to identify clients that have a custom host and standardizes that API for other clients.