### PR TITLE
Fix Missing Block in Chat API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai (1.6.0)
+    omniai (1.6.1)
       event_stream_parser
       http
       zeitwerk

--- a/lib/omniai/chat.rb
+++ b/lib/omniai/chat.rb
@@ -57,7 +57,11 @@ module OmniAI
     # @param stream [Proc, IO, nil] optional
     # @param tools [Array<OmniAI::Tool>] optional
     # @param format [Symbol, nil] optional - :json
+    #
     # @yield [prompt] optional
+    # @yieldparam prompt [OmniAI::Chat::Prompt]
+    #
+    # @return [OmniAi::Chat]
     def initialize(prompt = nil, client:, model:, temperature: nil, stream: nil, tools: nil, format: nil, &block)
       raise ArgumentError, 'prompt or block is required' if !prompt && !block
 

--- a/lib/omniai/client.rb
+++ b/lib/omniai/client.rb
@@ -131,8 +131,11 @@ module OmniAI
     # @param stream [Proc, nil] optional
     # @param tools [Array<OmniAI::Tool>] optional
     #
+    # @yield [prompt] optional
+    # @yieldparam prompt [OmniAI::Chat::Prompt]
+    #
     # @return [OmniAI::Chat::Completion]
-    def chat(messages, model:, temperature: nil, format: nil, stream: nil, tools: nil)
+    def chat(messages, model:, temperature: nil, format: nil, stream: nil, tools: nil, &)
       raise NotImplementedError, "#{self.class.name}#chat undefined"
     end
 

--- a/lib/omniai/version.rb
+++ b/lib/omniai/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniAI
-  VERSION = '1.6.0'
+  VERSION = '1.6.1'
 end


### PR DESCRIPTION
This ensures that the prompt builder can pass in a block.