### PR TITLE
Fix Ruby 3.3.0 support and add it to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,13 @@ orbs:
 
 executors:
   default:
+    parameters:
+      ruby-version:
+        description: "ruby version tag"
+        default: "3.4.1"
+        type: string
     docker:
-      - image: cimg/ruby:3.4.1
+      - image: cimg/ruby:<<parameters.ruby-version>>
 
 jobs:
   doc:
@@ -26,7 +31,13 @@ jobs:
       - ruby/install-deps
       - run: bundle exec yard doc
   rspec:
-    executor: default
+    parameters:
+      ruby-version:
+        description: "ruby version tag"
+        type: string
+    executor:
+      name: default
+      ruby-version: <<parameters.ruby-version>>
     steps:
       - checkout
       - ruby/install-deps
@@ -50,7 +61,10 @@ workflows:
   build:
     jobs:
       - doc
-      - rspec
+      - rspec:
+          matrix:
+            parameters:
+              ruby-version: ["3.4.1", "3.3.0"]
       - rubocop
       - release:
           filters:

--- a/lib/omniai/chat/stream.rb
+++ b/lib/omniai/chat/stream.rb
@@ -15,10 +15,10 @@ module OmniAI
 
       # @yield [payload]
       # @yieldparam payload [OmniAI::Chat::Payload]
-      def stream!(&)
+      def stream!(&block)
         @body.each do |chunk|
           parser.feed(chunk) do |type, data, id|
-            process!(type, data, id, &)
+            process!(type, data, id, &block)
           end
         end
       end

--- a/spec/omniai/chat/function_spec.rb
+++ b/spec/omniai/chat/function_spec.rb
@@ -12,7 +12,10 @@ RSpec.describe OmniAI::Chat::Function do
   describe "#inspect" do
     subject(:inspect) { function.inspect }
 
-    it { is_expected.to eq '#<OmniAI::Chat::Function name="temperature" arguments={"unit" => "celsius"}>' }
+    it do
+      expect(inspect)
+        .to eq "#<OmniAI::Chat::Function name=\"temperature\" arguments=#{{ 'unit' => 'celsius' }.inspect}>"
+    end
   end
 
   describe ".deserialize" do


### PR DESCRIPTION
The current implementation of `OmniAI::Chat::Stream#stream!` raises a `SyntaxError` in Ruby 3.3.0 due to the usage of a anonymous block parameter in nested blocks. The gemspec lists compatibility with Ruby >= 3.2.0 so I was hoping fixing up support for 3.3.0 would be considered 😃 

I've tweaked the CircleCI config to run the specs against Ruby 3.3.0 alongside 3.4.1 only at this stage, though more versions could very easily be added trivially.

The fix for the `SyntaxError` I'm proposing replaces the anonymous block `&` with `&block` like you're already doing elsewhere. I've also patched a minor compatibility issue with the way that `OmniAI::Chat::Function#inspect` was being tested as the output of `Hash#inspect` varies between Ruby versions as Ruby 3.3.0 omits spaces between the key, value and hash rocket

#### Screenshots of spec failures addressed:
![image](https://github.com/user-attachments/assets/8349b02e-d6ef-4ece-94ba-953df225d040)
![image](https://github.com/user-attachments/assets/a516ff01-ae5b-439e-a64f-d4ceb94200f9)


Thanks for your work on this gem :) 
