### PR TITLE
Link to DeepSeek

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "factory_bot"
+gem "irb"
 gem "rake"
 gem "rspec"
 gem "rspec_junit_formatter"

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source "https://rubygems.org"
 gemspec
 
 gem "factory_bot"
-gem "logger"
 gem "rake"
 gem "rspec"
 gem "rspec_junit_formatter"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai (1.9.3)
+    omniai (1.9.4)
       event_stream_parser
       http
       logger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     omniai (1.9.3)
       event_stream_parser
       http
+      logger
       zeitwerk
 
 GEM
@@ -153,7 +154,6 @@ PLATFORMS
 
 DEPENDENCIES
   factory_bot
-  logger
   omniai!
   rake
   rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
+    date (3.4.1)
     diff-lcs (1.5.1)
     docile (1.4.1)
     domain_name (0.6.20240107)
@@ -67,6 +68,11 @@ GEM
     http-form_data (2.3.0)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
+    io-console (0.8.0)
+    irb (1.15.1)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.9.1)
     language_server-protocol (3.17.0.3)
     llhttp-ffi (0.5.0)
@@ -78,11 +84,21 @@ GEM
     parser (3.3.7.0)
       ast (~> 2.4.1)
       racc
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
+    psych (5.2.3)
+      date
+      stringio
     public_suffix (6.0.1)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
+    rdoc (6.11.0)
+      psych (>= 4.0.0)
     regexp_parser (2.10.0)
+    reline (0.6.0)
+      io-console (~> 0.5)
     rexml (3.4.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -126,6 +142,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
+    stringio (3.1.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.1.4)
@@ -154,6 +171,7 @@ PLATFORMS
 
 DEPENDENCIES
   factory_bot
+  irb
   omniai!
   rake
   rspec

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 OmniAI standardizes the APIs of various AI / LLM companies such as Anthropic, Google, Mistral and OpenAI for the generation of text, the conversion of text-to-speech, the conversion of speech-to-text, the generation of embeddings, and more. It offers a unified API regardless of the provider and task.
 
 - [OmniAI::Anthropic](https://github.com/ksylvest/omniai-anthropic)
+- [OmniAI::DeepSeek](https://github.com/ksylvest/omniai-deepseek)
 - [OmniAI::Google](https://github.com/ksylvest/omniai-google)
 - [OmniAI::Mistral](https://github.com/ksylvest/omniai-mistral)
 - [OmniAI::OpenAI](https://github.com/ksylvest/omniai-openai)
@@ -167,12 +168,17 @@ search('Who do you call to fix a toilet?')
 
 ## Installation
 
+The main `omniai` gem is installed with:
+
 ```sh
 gem install omniai
 ```
 
+Specific provider gems are installed with:
+
 ```sh
 gem install omniai-anthropic
+gem install omniai-deepseek
 gem install omniai-mistral
 gem install omniai-google
 gem install omniai-openai
@@ -190,6 +196,14 @@ OmniAI implements APIs for a number of popular clients by default. A client can 
 require 'omniai/anthropic'
 
 client = OmniAI::Anthropic::Client.new
+```
+
+#### [OmniAI::DeepSeek](https://github.com/ksylvest/omniai-deepseek)
+
+```ruby
+require 'omniai/deepseek'
+
+client = OmniAI::DeepSeek::Client.new
 ```
 
 #### [OmniAI::Google](https://github.com/ksylvest/omniai-google)

--- a/lib/omniai/version.rb
+++ b/lib/omniai/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniAI
-  VERSION = "1.9.3"
+  VERSION = "1.9.4"
 end

--- a/omniai.gemspec
+++ b/omniai.gemspec
@@ -27,5 +27,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "event_stream_parser"
   spec.add_dependency "http"
+  spec.add_dependency "logger"
   spec.add_dependency "zeitwerk"
 end


### PR DESCRIPTION
This links to the DeepSeek OmniAI library. It also fixes a handful of warnings generated by the library w/ the latest version of Ruby.