### PR TITLE
Run CircleCI on latest v3.4 / v3.3 / v3.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,10 @@ workflows:
       - rspec:
           matrix:
             parameters:
-              ruby-version: ["3.4.1", "3.3.0"]
+              ruby-version:
+                - "3.4.1"
+                - "3.3.7"
+                - "3.2.6"
       - rubocop
       - release:
           filters:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai (1.9.4)
+    omniai (1.9.5)
       event_stream_parser
       http
       logger

--- a/lib/omniai/version.rb
+++ b/lib/omniai/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniAI
-  VERSION = "1.9.4"
+  VERSION = "1.9.5"
 end


### PR DESCRIPTION
This runs our CI on the latest version of Ruby supported in the gemspec. This also swaps our CI to properly wait for each version of Ruby to report back.