### PR TITLE
Close URI warning (security)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,7 +152,7 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
-    uri (1.0.2)
+    uri (1.0.3)
     webmock (3.25.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)


### PR DESCRIPTION
This removes the security warning with the URI v1.0.2 library by bumping to v1.0.3. This won't impact the published version and is a non-issue (just closing to avoid confusion).