### PR TITLE
Support Defining a Tool Using a `class` or `proc`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai (2.0.0)
+    omniai (2.1.0)
       event_stream_parser
       http
       logger

--- a/README.md
+++ b/README.md
@@ -88,23 +88,31 @@ require 'omniai/google'
 
 client = OmniAI::Google::Client.new
 
-tool = OmniAI::Tool.new(
-  proc { |location:, unit: "Celsius"| "#{rand(20..50)}° #{unit} in #{location}" },
-  name: "Weather",
-  description: "Lookup the weather in a location",
-  parameters: OmniAI::Tool::Parameters.new(
-    properties: {
-      location: OmniAI::Tool::Property.string(description: "e.g. Toronto"),
-      unit: OmniAI::Tool::Property.string(enum: %w[Celsius Fahrenheit]),
-    },
-    required: %i[location]
-  )
-)
+class Weather < OmniAI::Tool
+  description "Lookup the weather for a location"
 
-client.chat(stream: $stdout, tools: [tool]) do |prompt|
+  parameter :location, :string, description: "A location (e.g. 'Toronto, Canada')."
+  parameter :unit, :string, enum: %w[Celsius Fahrenheit], description: "The unit of measurement."
+  required %i[location]
+
+  # @param location [String] required
+  # @param unit [String] optional - "Celcius" or "Fahrenheit"
+  # @return [String]
+  def execute(location:, unit: "Celsius")
+    puts "[weather] location=#{location} unit=#{unit}"
+    "#{rand(20..50)}° #{unit} at #{location}"
+  end
+end
+
+client.chat(stream: $stdout, tools: [Weather.new]) do |prompt|
   prompt.system "You are an expert in weather."
   prompt.user 'What is the weather in "London" in Celsius and "Madrid" in Fahrenheit?'
 end
+```
+
+```
+[weather] location=London unit=Celsius
+[weather] location=Madrid unit=Fahrenheit
 ```
 
 ```

--- a/examples/chat_with_tools
+++ b/examples/chat_with_tools
@@ -5,20 +5,44 @@ require "omniai/google"
 
 client = OmniAI::Google::Client.new
 
-tool = OmniAI::Tool.new(
-  proc { |location:, unit: "Celsius"| "#{rand(20..50)}° #{unit} in #{location}" },
-  name: "Weather",
-  description: "Lookup the weather in a location",
+# A tool that randomly generates a temperature for a lat / lng in either Celsius or Fahrenheit.
+class Weather < OmniAI::Tool
+  description "Lookup the weather for a lat / lng"
+
+  parameter :lat, :number, description: "The latitude of the location."
+  parameter :lng, :number, description: "The longitude of the location."
+  parameter :unit, :string, enum: %w[Celsius Fahrenheit], description: "The unit of measurement."
+  required %i[lat lng]
+
+  # @param lat [Float]
+  # @param lng [Float]
+  # @param unit [String] "Celcius" or "Fahrenheit"
+  # @return [String]
+  def execute(lat:, lng:, unit: "Celsius")
+    puts "[weather] lat=#{lat} lng=#{lng} unit=#{unit}"
+    "#{rand(20..50)}° #{unit} at lat=#{lat} lng=#{lng}"
+  end
+end
+
+weather = Weather.new
+
+# A tool that randomly generates a lat / lng for a location.
+geocode = OmniAI::Tool.new(
+  proc do |location:|
+    puts "[geocode] location=#{location}"
+    "lat=#{rand(-90.0..+90.0)} lng=#{rand(-180.0..+180.0)} at location=#{location}"
+  end,
+  name: "geocode",
+  description: "Lookup the latitude and longitude of a location",
   parameters: OmniAI::Tool::Parameters.new(
     properties: {
       location: OmniAI::Tool::Property.string(description: "e.g. Toronto"),
-      unit: OmniAI::Tool::Property.string(enum: %w[Celsius Fahrenheit]),
     },
     required: %i[location]
   )
 )
 
-client.chat(stream: $stdout, tools: [tool]) do |prompt|
+client.chat(stream: $stdout, tools: [geocode, weather]) do |prompt|
   prompt.system "You are an expert in weather."
   prompt.user 'What is the weather in "London" in Celsius and "Madrid" in Fahrenheit?'
 end

--- a/lib/omniai/tool/property.rb
+++ b/lib/omniai/tool/property.rb
@@ -28,6 +28,19 @@ module OmniAI
       # @return [Array<String>, nil]
       attr_reader :enum
 
+      # @param kind [Symbol]
+      # @return [OmniAI::Tool::Property]
+      def self.build(kind, **args)
+        case kind
+        when :array then array(**args)
+        when :object then object(**args)
+        when :boolean then boolean(**args)
+        when :integer then integer(**args)
+        when :string then string(**args)
+        when :number then number(**args)
+        end
+      end
+
       # @example
       #   property = OmniAI::Tool::Property.array(
       #     items: OmniAI::Tool::Property.string(description: 'The name of the person.'),

--- a/lib/omniai/version.rb
+++ b/lib/omniai/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniAI
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end

--- a/spec/omniai/tool/property_spec.rb
+++ b/spec/omniai/tool/property_spec.rb
@@ -3,6 +3,56 @@
 RSpec.describe OmniAI::Tool::Property do
   subject(:property) { build(:tool_property) }
 
+  describe ".build" do
+    subject(:property) { described_class.build(kind, **options) }
+
+    context "when kind is ':array'" do
+      let(:kind) { :array }
+      let(:options) { { items: build(:tool_property, :string) } }
+
+      it { expect(property).to be_a(OmniAI::Tool::Array) }
+    end
+
+    context "when kind is ':object'" do
+      let(:kind) { :object }
+      let(:options) { { properties: { name: build(:tool_property, :string) }, required: %i[name] } }
+
+      it { expect(property).to be_a(OmniAI::Tool::Object) }
+    end
+
+    context "when kind is ':boolean'" do
+      let(:kind) { :boolean }
+      let(:options) { { description: "Either true or false" } }
+
+      it { expect(property).to be_a(described_class) }
+      it { expect(property.type).to eql("boolean") }
+    end
+
+    context "when kind is ':integer'" do
+      let(:kind) { :integer }
+      let(:options) { { description: "e.g. 1, 2, 3, ..." } }
+
+      it { expect(property).to be_a(described_class) }
+      it { expect(property.type).to eql("integer") }
+    end
+
+    context "when kind is ':string'" do
+      let(:kind) { :string }
+      let(:options) { { description: "e.g. 'the quick brown fox...'" } }
+
+      it { expect(property).to be_a(described_class) }
+      it { expect(property.type).to eql("string") }
+    end
+
+    context "when kind is ':number'" do
+      let(:kind) { :number }
+      let(:options) { { description: "e.g. 3.1415..." } }
+
+      it { expect(property).to be_a(described_class) }
+      it { expect(property.type).to eql("number") }
+    end
+  end
+
   describe ".array" do
     subject(:array) do
       described_class.array(items:, min_items:, max_items:)

--- a/spec/omniai/tool_spec.rb
+++ b/spec/omniai/tool_spec.rb
@@ -1,54 +1,112 @@
 # frozen_string_literal: true
 
+class Calculator < OmniAI::Tool
+  description "Either add or subtract a set of values."
+
+  parameter :values, :array, description: "A set of values.", items: OmniAI::Tool::Property.integer
+  parameter :operation, :string, enum: %w[+ -], description: "The operation to perform."
+  required %i[values operation]
+
+  # @param values [Array<Integer>]
+  # @param operation [String] "+" or "-"
+  def execute(values:, operation:)
+    case operation
+    when "+" then values.reduce(:+)
+    when "-" then values.reduce(:-)
+    end
+  end
+end
+
 RSpec.describe OmniAI::Tool do
-  subject(:tool) { described_class.new(fibonacci, name:, description:, parameters:) }
+  context "with a class" do
+    subject(:tool) { Calculator.new }
 
-  let(:fibonacci) do
-    proc do |n:|
-      next(0) if n == 0
-      next(1) if n == 1
-
-      fibonacci.call(n: n - 1) + fibonacci.call(n: n - 2)
-    end
-  end
-
-  let(:name) { "Fibonacci" }
-  let(:description) { "Calculate the nth Fibonacci" }
-
-  let(:parameters) do
-    OmniAI::Tool::Parameters.new(properties: {
-      n: OmniAI::Tool::Property.integer(description: "The nth Fibonacci number to calculate"),
-    }, required: %i[n])
-  end
-
-  describe "#serialize" do
-    it "converts the tool to a hash" do
-      expect(tool.serialize).to eq({
-        type: "function",
-        function: {
-          name:,
-          description:,
-          parameters: {
-            type: "object",
-            properties: {
-              n: { type: "integer", description: "The nth Fibonacci number to calculate" },
+    describe "#serialize" do
+      it "converts the tool to a hash" do
+        expect(tool.serialize).to eq({
+          type: "function",
+          function: {
+            name: "calculator",
+            description: "Either add or subtract a set of values.",
+            parameters: {
+              type: "object",
+              properties: {
+                values: {
+                  type: "array",
+                  description: "A set of values.",
+                  items: { type: "integer" },
+                },
+                operation: {
+                  type: "string",
+                  enum: %w[+ -],
+                  description: "The operation to perform.",
+                },
+              },
+              required: %i[values operation],
             },
-            required: %i[n],
           },
-        },
-      })
+        })
+      end
+    end
+
+    describe "#call" do
+      it "calls the proc" do
+        expect(tool.call({ "values" => [5, 3], "operation" => "+" })).to eq(8)
+        expect(tool.call({ "values" => [5, 3], "operation" => "-" })).to eq(2)
+      end
     end
   end
 
-  describe "#call" do
-    it "calls the proc" do
-      expect(tool.call({ "n" => 0 })).to eq(0)
-      expect(tool.call({ "n" => 1 })).to eq(1)
-      expect(tool.call({ "n" => 2 })).to eq(1)
-      expect(tool.call({ "n" => 3 })).to eq(2)
-      expect(tool.call({ "n" => 4 })).to eq(3)
-      expect(tool.call({ "n" => 5 })).to eq(5)
-      expect(tool.call({ "n" => 6 })).to eq(8)
+  context "with a proc" do
+    subject(:tool) { described_class.new(fibonacci, name:, description:, parameters:) }
+
+    let(:fibonacci) do
+      proc do |n:|
+        next(0) if n == 0
+        next(1) if n == 1
+
+        fibonacci.call(n: n - 1) + fibonacci.call(n: n - 2)
+      end
+    end
+
+    let(:name) { "Fibonacci" }
+    let(:description) { "Calculate the nth Fibonacci" }
+
+    let(:parameters) do
+      OmniAI::Tool::Parameters.new(properties: {
+        n: OmniAI::Tool::Property.integer(description: "The nth Fibonacci number to calculate"),
+      }, required: %i[n])
+    end
+
+    describe "#serialize" do
+      it "converts the tool to a hash" do
+        expect(tool.serialize).to eq({
+          type: "function",
+          function: {
+            name:,
+            description:,
+            parameters: {
+              type: "object",
+              properties: {
+                n: { type: "integer", description: "The nth Fibonacci number to calculate" },
+              },
+              required: %i[n],
+            },
+          },
+        })
+      end
+    end
+
+    describe "#call" do
+      it "calls the proc" do
+        expect(tool.call({ "n" => 0 })).to eq(0)
+        expect(tool.call({ "n" => 1 })).to eq(1)
+        expect(tool.call({ "n" => 2 })).to eq(1)
+        expect(tool.call({ "n" => 3 })).to eq(2)
+        expect(tool.call({ "n" => 4 })).to eq(3)
+        expect(tool.call({ "n" => 5 })).to eq(5)
+        expect(tool.call({ "n" => 6 })).to eq(8)
+      end
     end
   end
 end


### PR DESCRIPTION
This introduces the ability to build a tool with either a class or proc syntax. The class method of defining tools is a bit easier to parse for many.

## Building a Tool w/ a Class

```ruby
class Weather < OmniAI::Tool
  description "Find the weather for a given location"

  parameter :location, :string, description: "A location (e.g. 'Toronto, Canada')."
  parameter :unit, :string, enum: %w[Celsius Fahrenheit], description: "The unit of measurement."
  required %i[location]

  # @param location [String] required
  # @param unit [String] optional - "Celcius" or "Fahrenheit"
  # @return [String]
  def execute(location:, unit: "Celsius")
    "#{rand(20..50)}° #{unit} at #{location}"
  end
end

tools = [Weather.new]
client.chat(stream: $stdout, tools:)
```

## Building a Tool w/ a Proc

```ruby
weather = OmniAI::Tool.new(
  proc do |location:, unit: "Celsius"|
    "#{rand(20..50)}° #{unit} at #{location}"
  end,
  name: "weather",
  description: "Find the weather for a given location",
)

tools = [weather]
client.chat(stream: $stdout, tools:)
```
