### PR TITLE
Fallback to `prompt_tokens` and `completion_tokens` for `usage

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai (2.1.0)
+    omniai (2.1.1)
       event_stream_parser
       http
       logger

--- a/lib/omniai/chat/usage.rb
+++ b/lib/omniai/chat/usage.rb
@@ -35,8 +35,8 @@ module OmniAI
         deserialize = context&.deserializer(:usage)
         return deserialize.call(data, context:) if deserialize
 
-        input_tokens = data["input_tokens"]
-        output_tokens = data["output_tokens"]
+        input_tokens = data["input_tokens"] || data["prompt_tokens"]
+        output_tokens = data["output_tokens"] || data["completion_tokens"]
         total_tokens = data["total_tokens"]
 
         new(input_tokens:, output_tokens:, total_tokens:)

--- a/lib/omniai/version.rb
+++ b/lib/omniai/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniAI
-  VERSION = "2.1.0"
+  VERSION = "2.1.1"
 end


### PR DESCRIPTION
For usage, some APIs name them as `input_tokens` / `output_tokens` and some APIs use `prompt_tokens` / `completion_tokens`.