### PR TITLE
Support the MCP standard for `tools-call` / `tools-list` APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,3 +530,44 @@ Type 'exit' or 'quit' to abort.
 0.0
 ...
 ```
+
+### MCP
+
+[MCP](https://modelcontextprotocol.io/introduction) is an open protocol designed to standardize giving context to LLMs. The OmniAI implementation supports building an MCP server that operates via the [stdio](https://modelcontextprotocol.io/docs/concepts/transports) transport.
+
+**main.rb**
+
+```ruby
+class Weather < OmniAI::Tool
+  description "Lookup the weather for a location"
+
+  parameter :location, :string, description: "A location (e.g. 'London' or 'Madrid')."
+  required %i[location]
+
+  # @param location [String] required
+  # @return [String]
+  def execute(location:)
+    case location
+    when 'London' then 'Rainy'
+    when 'Madrid' then 'Sunny'
+    end
+  end
+end
+
+transport = OmniAI::MCP::Transport::Stdio.new
+mcp = OmniAI::MCP::Server.new(tools: [Weather.new])
+mcp.run(transport:)
+```
+
+```bash
+ruby main.rb
+```
+
+```bash
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": { "name": "echo", "arguments": { "message": "Hello, world!" } }
+}
+```

--- a/examples/mcp
+++ b/examples/mcp
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "omniai"
+
+# A tool that randomly generates a temperature for a lat / lng in either Celsius or Fahrenheit.
+class Weather < OmniAI::Tool
+  description "Lookup the weather for a lat / lng"
+
+  parameter :lat, :number, description: "The latitude of the location."
+  parameter :lng, :number, description: "The longitude of the location."
+  parameter :unit, :string, enum: %w[Celsius Fahrenheit], description: "The unit of measurement."
+  required %i[lat lng]
+
+  # @param lat [Float]
+  # @param lng [Float]
+  # @param unit [String] "Celcius" or "Fahrenheit"
+  # @return [String]
+  def execute(lat:, lng:, unit: "Celsius")
+    "#{rand(20..50)}° #{unit} at lat=#{lat} lng=#{lng}"
+  end
+end
+
+mcp = OmniAI::MCP::Server.new(tools: [Weather.new])
+mcp.run

--- a/lib/omniai.rb
+++ b/lib/omniai.rb
@@ -8,8 +8,10 @@ require "zeitwerk"
 
 loader = Zeitwerk::Loader.for_gem
 loader.inflector.inflect "omniai" => "OmniAI"
-loader.inflector.inflect "url" => "URL"
 loader.inflector.inflect "cli" => "CLI"
+loader.inflector.inflect "jrpc" => "JRPC"
+loader.inflector.inflect "mcp" => "MCP"
+loader.inflector.inflect "url" => "URL"
 loader.setup
 
 module OmniAI

--- a/lib/omniai/mcp/jrpc.rb
+++ b/lib/omniai/mcp/jrpc.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module OmniAI
+  module MCP
+    # @example
+    #   OmniAI::MCP::JRPC::VERSION
+    module JRPC
+      VERSION = "2.0"
+    end
+  end
+end

--- a/lib/omniai/mcp/jrpc/error.rb
+++ b/lib/omniai/mcp/jrpc/error.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module OmniAI
+  module MCP
+    module JRPC
+      # @example
+      #   raise OmniAI::MCP::JRPC::Error.new(code: OmniAI::MCP::JRPC::Error::PARSE_ERROR, message: "Invalid JSON")
+      class Error < StandardError
+        module Code
+          PARSE_ERROR = -32_700
+          INVALID_REQUEST = -32_600
+          METHOD_NOT_FOUND = -32_601
+          INVALID_PARAMS = -32_602
+          INTERNAL_ERROR = -32_603
+        end
+
+        # @!attribute [r] code
+        #   @return [Integer]
+        attr_accessor :code
+
+        # @!attribute [r] message
+        #   @return [String]
+        attr_accessor :message
+
+        # @param code [Integer]
+        # @param message [String]
+        def initialize(code:, message:)
+          super("code=#{code} message=#{message}")
+
+          @code = code
+          @message = message
+        end
+      end
+    end
+  end
+end

--- a/lib/omniai/mcp/jrpc/request.rb
+++ b/lib/omniai/mcp/jrpc/request.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module OmniAI
+  module MCP
+    module JRPC
+      # @example
+      #   request = OmniAI::MCP::JRPC::Request.new(id: 0, method: "ping", params: {})
+      #   request.id #=> 0
+      #   request.method #=> "ping"
+      #   request.params #=> {}
+      class Request
+        # @!attribute [rw] id
+        #   @return [Integer]
+        attr_accessor :id
+
+        # @!attribute [rw] method
+        #   @return [String]
+        attr_accessor :method
+
+        # @!attribute [rw] params
+        #   @return [Hash]
+        attr_accessor :params
+
+        # @param id [Integer]
+        # @param method [String]
+        # @param params [Hash]
+        def initialize(id:, method:, params:)
+          @id = id
+          @method = method
+          @params = params
+        end
+
+        # @return [String]
+        def inspect
+          "#<#{self.class.name} id=#{@id} method=#{@method} params=#{@params}>"
+        end
+
+        # @return [String]
+        def generate
+          JSON.generate({
+            jsonrpc: VERSION,
+            id: @id,
+            method: @method,
+            params: @params,
+          })
+        end
+
+        # @param text [String]
+        #
+        # @raise [OmniAI::MCP::JRPC::Error]
+        #
+        # @return [OmniAI::MCP::JRPC::Request]
+        def self.parse(text)
+          data =
+            begin
+              JSON.parse(text)
+            rescue JSON::ParserError => e
+              raise Error.new(code: Error::Code::PARSE_ERROR, message: e.message)
+            end
+
+          id = data["id"] || raise(Error.new(code: Error::Code::PARSE_ERROR, message: "missing id"))
+          method = data["method"] || raise(Error.new(code: Error::Code::PARSE_ERROR, message: "missing method"))
+          params = data["params"] || raise(Error.new(code: Error::Code::PARSE_ERROR, message: "missing params"))
+
+          new(id:, method:, params:)
+        end
+      end
+    end
+  end
+end

--- a/lib/omniai/mcp/jrpc/response.rb
+++ b/lib/omniai/mcp/jrpc/response.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module OmniAI
+  module MCP
+    module JRPC
+      # @example
+      #   request = OmniAI::MCP::JRPC::Response.new(id: 0, result: "OK")
+      #   request.generate #=> { "jsonrpc": "2.0", "id": 0, "result": "OK" }
+      class Response
+        # @!attribute [rw] id
+        #   @return [Integer]
+        attr_accessor :id
+
+        # @!attribute [rw] result
+        #   @return [String]
+        attr_accessor :result
+
+        # @param id [Integer]
+        # @param result [String]
+        def initialize(id:, result:)
+          @id = id
+          @result = result
+        end
+
+        # @return [String]
+        def inspect
+          "#<#{self.class.name} id=#{@id} result=#{@result}>"
+        end
+
+        # @return [String]
+        def generate
+          JSON.generate({
+            jsonrpc: VERSION,
+            id: @id,
+            result: @result,
+          })
+        end
+
+        # @param text [String]
+        #
+        # @raise [OmniAI::MCP::JRPC::Error]
+        #
+        # @return [OmniAI::MCP::JRPC::Response]
+        def self.parse(text)
+          data =
+            begin
+              JSON.parse(text)
+            rescue JSON::ParserError => e
+              raise Error.new(code: Error::Code::PARSE_ERROR, message: e.message)
+            end
+
+          id = data["id"] || raise(Error.new(code: Error::Code::PARSE_ERROR, message: "missing id"))
+          result = data["result"] || raise(Error.new(code: Error::Code::PARSE_ERROR, message: "missing result"))
+
+          new(id:, result:)
+        end
+      end
+    end
+  end
+end

--- a/lib/omniai/mcp/server.rb
+++ b/lib/omniai/mcp/server.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+module OmniAI
+  module MCP
+    # @example
+    #   server = OmniAI::MCP::Server.new(tools: [...])
+    #   server.run
+    class Server
+      PROTOCOL_VERSION = "2025-03-26"
+
+      # @param tools [Array<OmniAI::Tool>]
+      # @param logger [Logger, nil]
+      def initialize(tools:, logger: nil, name: "OmniAI", version: OmniAI::VERSION)
+        @tools = tools
+        @logger = logger
+        @name = name
+        @version = version
+      end
+
+      # @param transport [OmniAI::MCP::Transport]
+      def run(transport: OmniAI::MCP::Transport::Stdio.new)
+        loop do
+          message = transport.gets
+          break if message.nil?
+
+          @logger&.info("#{self.class}#run: message=#{message.inspect}")
+          response = process(message)
+          @logger&.info("#{self.class}#run: response=#{response.inspect}")
+
+          transport.puts(response) if response
+        end
+      end
+
+    private
+
+      # @param message [String]
+      #
+      # @return [String, nil]
+      def process(message)
+        request = JRPC::Request.parse(message)
+
+        response =
+          case request.method
+          when "initialize" then process_initialize(request:)
+          when "ping" then process_ping(request:)
+          when "tools/list" then process_tools_list(request:)
+          when "tools/call" then process_tools_call(request:)
+          end
+
+        response&.generate if response&.result
+      rescue JRPC::Error => e
+        JSON.generate({
+          jsonrpc: JRPC::VERSION,
+          id: request&.id,
+          error: {
+            code: e.code,
+            message: e.message,
+          },
+        })
+      end
+
+      # @param request [JRPC::Request]
+      # @return [JRPC::Response]
+      def process_initialize(request:)
+        JRPC::Response.new(id: request.id, result: {
+          protocolVersion: PROTOCOL_VERSION,
+          serverInfo: {
+            name: @name,
+            version: @version,
+          },
+          capabilities: {},
+        })
+      end
+
+      # @param request [JRPC::Request]
+      # @return [JRPC::Response]
+      def process_ping(request:)
+        JRPC::Response.new(id: request.id, result: {})
+      end
+
+      # @param request [JRPC::Request]
+      #
+      # @raise [JRPC::Error]
+      #
+      # @return [JRPC::Response]
+      def process_tools_list(request:)
+        result = @tools.map do |tool|
+          {
+            name: tool.name,
+            description: tool.description,
+            inputSchema: tool.parameters.serialize,
+          }
+        end
+
+        JRPC::Response.new(id: request.id, result:)
+      end
+
+      # @param request [JRPC::Request]
+      #
+      # @raise [JRPC::Error]
+      #
+      # @return [JRPC::Response]
+      def process_tools_call(request:)
+        name = request.params["name"]
+        tool = @tools.find { |tool| tool.name.eql?(name) }
+
+        result =
+          begin
+            tool.call(request.params["input"])
+          rescue StandardError => e
+            raise JRPC::Error.new(code: JRPC::Error::Code::INTERNAL_ERROR, message: e.message)
+          end
+
+        JRPC::Response.new(id: request.id, result:)
+      end
+    end
+  end
+end

--- a/lib/omniai/mcp/transport/base.rb
+++ b/lib/omniai/mcp/transport/base.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module OmniAI
+  module MCP
+    module Transport
+      # @example
+      #   transport = OmniAI::MCP::Transport::Base.new
+      #   transport.puts("Hello World")
+      #   transport.gets
+      class Base
+        # @param text [String]
+        def puts(text)
+          raise NotImplementedError, "#{self.class}#gets undefined"
+        end
+
+        # @return [String]
+        def gets
+          raise NotImplementedError, "#{self.class}#gets undefined"
+        end
+      end
+    end
+  end
+end

--- a/lib/omniai/mcp/transport/stdio.rb
+++ b/lib/omniai/mcp/transport/stdio.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module OmniAI
+  module MCP
+    module Transport
+      # @example
+      #   transport = OmniAI::MCP::Transport::Stdio.new
+      #   transport.puts("Hello World")
+      #   transport.gets
+      class Stdio < Base
+        # @param stdin [IO]
+        # @param stdout [IO]
+        # @param stderr [IO]
+        def initialize(stdin: $stdin, stdout: $stdout, stderr: $stderr)
+          super()
+          @stdin = stdin
+          @stdout = stdout
+          @stderr = stderr
+        end
+
+        # @param text [String]
+        def puts(text)
+          @stdout.puts(text)
+        end
+
+        # @return [String]
+        def gets
+          @stdin.gets
+        end
+      end
+    end
+  end
+end

--- a/lib/omniai/tool.rb
+++ b/lib/omniai/tool.rb
@@ -72,7 +72,7 @@ module OmniAI
     # @param function [Proc]
     # @param name [String]
     # @param description [String]
-    # @param parameters [Hash]
+    # @param parameters [OmniAI::Tool::Parameters]
     def initialize(
       function = method(:execute),
       name: self.class.namify,

--- a/spec/factories/tool.rb
+++ b/spec/factories/tool.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :tool, class: "OmniAI::Tool" do
+    initialize_with { new(function, name:, description:, parameters:) }
+
+    function do
+      proc do |location:|
+        case location
+        when "London" then "Rainy"
+        when "Madrid" then "Sunny"
+        else raise ArgumentError, "unknown location=#{location}"
+        end
+      end
+    end
+
+    name { "weather" }
+    description { "Finds the weather for a location." }
+
+    parameters do
+      OmniAI::Tool::Parameters.new(properties: { location: OmniAI::Tool::Property.string }, required: ["location"])
+    end
+  end
+end

--- a/spec/factories/tool/parameters.rb
+++ b/spec/factories/tool/parameters.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :tool_parameters, class: "OmniAI::Tool::Parameters", parent: :tool_object
+end

--- a/spec/omniai/mcp/jrpc/request_spec.rb
+++ b/spec/omniai/mcp/jrpc/request_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe OmniAI::MCP::JRPC::Request do
+  describe ".parse" do
+    subject(:parse) { described_class.parse(text) }
+
+    let(:text) { '{"jsonrpc":"2.0","id":0,"method":"ping","params":{}}' }
+
+    context "with valid JSON" do
+      it "parses" do
+        expect(parse).to be_a(described_class)
+        expect(parse.id).to be(0)
+        expect(parse.method).to eql("ping")
+        expect(parse.params).to eql({})
+      end
+    end
+
+    context "with invalid JSON" do
+      let(:text) { "}{" }
+
+      it "raises an error" do
+        expect { parse }.to raise_error(OmniAI::MCP::JRPC::Error)
+      end
+    end
+  end
+
+  describe "#generate" do
+    subject(:generate) { request.generate }
+
+    let(:request) { described_class.new(id: 0, method: "ping", params: {}) }
+
+    it "generates" do
+      expect(generate).to eql('{"jsonrpc":"2.0","id":0,"method":"ping","params":{}}')
+    end
+  end
+
+  describe "#inspect" do
+    subject(:inspect) { request.inspect }
+
+    let(:request) { described_class.new(id: 0, method: "ping", params: {}) }
+
+    it "inspects" do
+      expect(inspect).to eql("#<OmniAI::MCP::JRPC::Request id=0 method=ping params={}>")
+    end
+  end
+end

--- a/spec/omniai/mcp/jrpc/response_spec.rb
+++ b/spec/omniai/mcp/jrpc/response_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe OmniAI::MCP::JRPC::Response do
+  describe ".parse" do
+    subject(:parse) { described_class.parse(text) }
+
+    context "with valid JSON" do
+      let(:text) { '{"jsonrpc":"2.0","id":0,"result":"OK"}' }
+
+      it "parses" do
+        expect(parse).to be_a(described_class)
+        expect(parse.id).to be(0)
+        expect(parse.result).to eql("OK")
+      end
+    end
+
+    context "with invalid JSON" do
+      let(:text) { "}{" }
+
+      it "raises an error" do
+        expect { parse }.to raise_error(OmniAI::MCP::JRPC::Error)
+      end
+    end
+  end
+
+  describe "#generate" do
+    subject(:generate) { request.generate }
+
+    let(:request) { described_class.new(id: 0, result: "OK") }
+
+    it "generates" do
+      expect(generate).to eql('{"jsonrpc":"2.0","id":0,"result":"OK"}')
+    end
+  end
+
+  describe "#inspect" do
+    subject(:inspect) { request.inspect }
+
+    let(:request) { described_class.new(id: 0, result: "OK") }
+
+    it "inspects" do
+      expect(inspect).to eql("#<OmniAI::MCP::JRPC::Response id=0 result=OK>")
+    end
+  end
+end

--- a/spec/omniai/mcp/server_spec.rb
+++ b/spec/omniai/mcp/server_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+RSpec.describe OmniAI::MCP::Server do
+  subject(:server) { described_class.new(tools: [tool]) }
+
+  let(:tool) { build(:tool) }
+  let(:transport) { OmniAI::MCP::Transport::Stdio.new(stdin:, stdout:, stderr:) }
+  let(:stdin) { StringIO.new }
+  let(:stdout) { StringIO.new }
+  let(:stderr) { StringIO.new }
+
+  describe "#run" do
+    subject(:run) do
+      stdin << input
+      stdin.rewind
+      server.run(transport:)
+      stdout.string
+    end
+
+    context "when processing initialize" do
+      let(:input) do
+        <<~JSON
+          #{JSON.generate(jsonrpc: '2.0', id: 0, method: 'initialize', params: {})}
+        JSON
+      end
+
+      let(:output) do
+        <<~JSON
+          #{JSON.generate(jsonrpc: '2.0', id: 0, result: {
+            protocolVersion: described_class::PROTOCOL_VERSION,
+            serverInfo: {
+              name: 'OmniAI',
+              version: OmniAI::VERSION,
+            },
+            capabilities: {},
+          })}
+        JSON
+      end
+
+      it "returns a response" do
+        expect(run).to eql(output)
+      end
+    end
+
+    context "when processing ping" do
+      let(:input) do
+        <<~JSON
+          #{JSON.generate(jsonrpc: '2.0', id: 0, method: 'ping', params: {})}
+        JSON
+      end
+
+      let(:output) do
+        <<~JSON
+          #{JSON.generate(jsonrpc: '2.0', id: 0, result: {})}
+        JSON
+      end
+
+      it "returns a response" do
+        expect(run).to eql(output)
+      end
+    end
+
+    context "when processing tools/list" do
+      let(:input) do
+        <<~JSON
+          #{JSON.generate(jsonrpc: '2.0', id: 0, method: 'tools/list', params: {})}
+        JSON
+      end
+
+      let(:output) do
+        <<~JSON
+          #{JSON.generate(jsonrpc: '2.0', id: 0, result: [
+            {
+              name: 'weather',
+              description: 'Finds the weather for a location.',
+              inputSchema: {
+                type: 'object',
+                properties: { location: { type: 'string' } },
+                required: ['location'],
+              },
+            },
+          ])}
+        JSON
+      end
+
+      it "returns a response" do
+        expect(run).to eql(output)
+      end
+    end
+
+    context "when processing tools/call for weather in london" do
+      let(:input) do
+        <<~JSON
+          #{JSON.generate(jsonrpc: '2.0', id: 0, method: 'tools/call', params: {
+            name: 'weather',
+            input: { location: 'London' },
+          })}
+        JSON
+      end
+
+      let(:output) do
+        <<~JSON
+          #{JSON.generate(jsonrpc: '2.0', id: 0, result: 'Rainy')}
+        JSON
+      end
+
+      it "returns a response" do
+        expect(run).to eql(output)
+      end
+    end
+
+    context "when processing tools/call for weather in madrid" do
+      let(:input) do
+        <<~JSON
+          #{JSON.generate(jsonrpc: '2.0', id: 0, method: 'tools/call', params: {
+            name: 'weather',
+            input: { location: 'Madrid' },
+          })}
+        JSON
+      end
+
+      let(:output) do
+        <<~JSON
+          #{JSON.generate(jsonrpc: '2.0', id: 0, result: 'Sunny')}
+        JSON
+      end
+
+      it "returns a response" do
+        expect(run).to eql(output)
+      end
+    end
+
+    context "when processing tools/call for weather in toronto" do
+      let(:input) do
+        <<~JSON
+          #{JSON.generate(jsonrpc: '2.0', id: 0, method: 'tools/call', params: {
+            name: 'weather',
+            input: { location: 'Toronto' },
+          })}
+        JSON
+      end
+
+      let(:output) do
+        <<~JSON
+          #{JSON.generate(jsonrpc: '2.0', id: 0, error: {
+            code: OmniAI::MCP::JRPC::Error::Code::INTERNAL_ERROR,
+            message: 'unknown location=Toronto',
+          })}
+        JSON
+      end
+
+      it "returns a response" do
+        expect(run).to eql(output)
+      end
+    end
+  end
+end

--- a/spec/omniai/mcp/transport/base_spec.rb
+++ b/spec/omniai/mcp/transport/base_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe OmniAI::MCP::Transport::Base do
+  subject(:transport) { described_class.new }
+
+  describe "#puts" do
+    it "raises NotImplementedError" do
+      expect { transport.puts("Hello World") }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "#gets" do
+    it "raises NotImplementedError" do
+      expect { transport.gets }.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/omniai/mcp/transport/stdio_spec.rb
+++ b/spec/omniai/mcp/transport/stdio_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe OmniAI::MCP::Transport::Stdio do
+  subject(:transport) { described_class.new(stdin:, stdout:, stderr:) }
+
+  let(:stdin) { StringIO.new }
+  let(:stdout) { StringIO.new }
+  let(:stderr) { StringIO.new }
+
+  describe "#puts" do
+    it "puts to stdout" do
+      transport.puts("Hello World")
+      expect(stdout.string).to eq("Hello World\n")
+    end
+  end
+
+  describe "#gets" do
+    it "gets from stdin" do
+      stdin.puts("Hello World")
+      stdin.rewind
+      expect(transport.gets).to eq("Hello World\n")
+    end
+  end
+end


### PR DESCRIPTION
## Context
[MCP](https://modelcontextprotocol.io/introduction) is an open protocol designed to standardize giving context to LLMs. The OmniAI implementation supports building an MCP server that operates via the [stdio](https://modelcontextprotocol.io/docs/concepts/transports) transport. The purpose of this protocol is to offer a standard approach for implementing `tools-call` and `tools-list` via OmniAI tools. The spec is fairly difficult to debug and thus the documentation isn't yet moved into the README. The following syntax should work:

**main.rb**

```ruby
class Weather < OmniAI::Tool
  description "Lookup the weather for a location"

  parameter :location, :string, description: "A location (e.g. 'London' or 'Madrid')."
  required %i[location]

  # @param location [String] required
  # @return [String]
  def execute(location:)
    case location
    when 'London' then 'Rainy'
    when 'Madrid' then 'Sunny'
    end
  end
end

transport = OmniAI::MCP::Transport::Stdio.new
mcp = OmniAI::MCP::Server.new(tools: [Weather.new])
mcp.run(transport:)
```

```bash
ruby main.rb
```

Fixes: https://github.com/ksylvest/omniai/issues/143