### PR TITLE
Support Optional Params for Embedding

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai (2.2.0)
+    omniai (2.3.0)
       event_stream_parser
       http
       logger

--- a/lib/omniai/embed.rb
+++ b/lib/omniai/embed.rb
@@ -64,7 +64,12 @@ module OmniAI
       @client
         .connection
         .accept(:json)
-        .post(path, json: payload)
+        .post(path, params:, json: payload)
+    end
+
+    # @return [Hash]
+    def params
+      {}
     end
 
     # @return [Hash]

--- a/lib/omniai/version.rb
+++ b/lib/omniai/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniAI
-  VERSION = "2.2.0"
+  VERSION = "2.3.0"
 end

--- a/spec/omniai/embed_spec.rb
+++ b/spec/omniai/embed_spec.rb
@@ -15,6 +15,10 @@ class FakeEmbed < OmniAI::Embed
     "/embed"
   end
 
+  def params
+    { api_key: "fake-api-key" }
+  end
+
   def payload
     { input: @input, model: @model }
   end
@@ -43,7 +47,7 @@ RSpec.describe OmniAI::Embed do
 
     context "when OK" do
       before do
-        stub_request(:post, "http://localhost:8080/embed")
+        stub_request(:post, "http://localhost:8080/embed?api_key=fake-api-key")
           .with(body: {
             input:,
             model:,
@@ -61,7 +65,7 @@ RSpec.describe OmniAI::Embed do
 
     context "when UNPROCESSABLE" do
       before do
-        stub_request(:post, "http://localhost:8080/embed")
+        stub_request(:post, "http://localhost:8080/embed?api_key=fake-api-key")
           .with(body: {
             input:,
             model:,


### PR DESCRIPTION
This is helpful to handle serializing API keys in a more consistent way.