### PR TITLE
Shortcuts for `Client.chat`, `Client.speak`, `Client.transcribe` and `Client.embed`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai (2.6.0)
+    omniai (2.7.0)
       event_stream_parser
       http
       logger

--- a/lib/omniai.rb
+++ b/lib/omniai.rb
@@ -16,6 +16,68 @@ loader.inflector.inflect "http_error" => "HTTPError"
 loader.inflector.inflect "ssl_error" => "SSLError"
 loader.setup
 
+# @example
+#
+#   OmniAI.chat(...)
+#   OmniAI.transcribe(...)
+#   OmniAI.speak(...)
+#   OmniAI.embed(...)
 module OmniAI
   class Error < StandardError; end
+
+  # Discover a client by provider ('openai' then 'anthropic' then 'google' then 'mistral' then 'deepseek').
+  #
+  # @param provider [Symbol] the provider to use (e.g. :openai, :anthropic, :google, :mistral, :deepseek) - optional
+  #
+  # @raise [OmniAI::LoadError] if no providers are installed
+  #
+  # @return [OmniAI::Client]
+  def self.client(provider: nil, **)
+    provider ? OmniAI::Client.find(provider:, **) : OmniAI::Client.discover(**)
+  end
+
+  # @example
+  #   response = OmniAI.chat("What is the capital of Spain?")
+  #   puts response.text
+  #
+  # @example
+  #   OmniAI.chat(stream: $stdout) do |prompt|
+  #     prompt.system("Answer in both English and French.")
+  #     prompt.user("How many people live in Tokyo?")
+  #   end
+  #
+  # @see OmniAI::Client#chat
+  def self.chat(...)
+    client.chat(...)
+  end
+
+  # @example
+  #   File.open("audio.wav", "rb") do |file|
+  #     puts OmniAI.transcribe(file).text
+  #   end
+  #
+  # @see OmniAI::Client#transcribe
+  def self.transcribe(...)
+    client.transcribe(...)
+  end
+
+  # @example
+  #   File.open("audio.wav", "wb") do |file|
+  #     OmniAI.speak("Sally sells seashells by the seashore.") do |chunk|
+  #       file << chunk
+  #     end
+  #   end
+  #
+  # @see OmniAI::Client#speak
+  def self.speak(...)
+    client.speak(...)
+  end
+
+  # @example
+  #   embedding = OmniAI.embed("The quick brown fox jumps over the lazy dog.").embedding
+  #
+  # @see OmniAI::Client#embed
+  def self.embed(...)
+    client.embed(...)
+  end
 end

--- a/lib/omniai/client.rb
+++ b/lib/omniai/client.rb
@@ -34,69 +34,93 @@ module OmniAI
 
     # Initialize a client for Anthropic. This method requires the provider if it is undefined.
     #
-    # @raise [OmniAI::Error] if the provider is not defined and the gem is not installed
+    # @raise [OmniAI::LoadError] if the provider is not defined and the gem is not installed
     #
     # @return [Class<OmniAI::Client>]
     def self.anthropic
       require "omniai/anthropic" unless defined?(OmniAI::Anthropic::Client)
       OmniAI::Anthropic::Client
     rescue ::LoadError
-      raise Error, "requires 'omniai-anthropic': `gem install omniai-anthropic`"
+      raise LoadError, "requires 'omniai-anthropic': `gem install omniai-anthropic`"
     end
 
     # Initialize a client for DeepSeek. This method requires the provider if it is undefined.
     #
-    # @raise [OmniAI::Error] if the provider is not defined and the gem is not installed
+    # @raise [OmniAI::LoadError] if the provider is not defined and the gem is not installed
     #
     # @return [Class<OmniAI::Client>]
     def self.deepseek
       require "omniai/deepseek" unless defined?(OmniAI::DeepSeek::Client)
       OmniAI::DeepSeek::Client
     rescue ::LoadError
-      raise Error, "requires 'omniai-deepseek': `gem install omniai-deepseek`"
+      raise LoadError, "requires 'omniai-deepseek': `gem install omniai-deepseek`"
     end
 
     # Lookup the `OmniAI::Google::Client``. This method requires the provider if it is undefined.
     #
-    # @raise [OmniAI::Error] if the provider is not defined and the gem is not installed
+    # @raise [OmniAI::LoadError] if the provider is not defined and the gem is not installed
     #
     # @return [Class<OmniAI::Client>]
     def self.google
       require "omniai/google" unless defined?(OmniAI::Google::Client)
       OmniAI::Google::Client
     rescue ::LoadError
-      raise Error, "requires 'omniai-google': `gem install omniai-google`"
+      raise LoadError, "requires 'omniai-google': `gem install omniai-google`"
     end
 
     # Initialize a client for Mistral. This method requires the provider if it is undefined.
     #
-    # @raise [OmniAI::Error] if the provider is not defined and the gem is not installed
+    # @raise [OmniAI::LoadError] if the provider is not defined and the gem is not installed
     #
     # @return [Class<OmniAI::Client>]
     def self.mistral
       require "omniai/mistral" unless defined?(OmniAI::Mistral::Client)
       OmniAI::Mistral::Client
     rescue ::LoadError
-      raise Error, "requires 'omniai-mistral': `gem install omniai-mistral`"
+      raise LoadError, "requires 'omniai-mistral': `gem install omniai-mistral`"
     end
 
     # Initialize a client for OpenAI. This method requires the provider if it is undefined.
     #
-    # @raise [OmniAI::Error] if the provider is not defined and the gem is not installed
+    # @raise [OmniAI::LoadError] if the provider is not defined and the gem is not installed
     #
     # @return [Class<OmniAI::Client>]
     def self.openai
       require "omniai/openai" unless defined?(OmniAI::OpenAI::Client)
       OmniAI::OpenAI::Client
     rescue ::LoadError
-      raise Error, "requires 'omniai-openai': `gem install omniai-openai`"
+      raise LoadError, "requires 'omniai-openai': `gem install omniai-openai`"
+    end
+
+    # Discover a client by provider ('openai' then 'anthropic' then 'google' then 'mistral' then 'deepseek').
+    #
+    # @raise [OmniAI::LoadError] if no providers are installed
+    #
+    # @return [OmniAI::Client]
+    def self.discover(**)
+      %i[openai anthropic google mistral deepseek].each do |provider|
+        return find(provider:, **)
+      rescue LoadError
+        next
+      end
+
+      raise LoadError, <<~TEXT
+        requires 'omniai-openai' or 'omniai-anthropic' or 'openai-deepseek' or 'omniai-google' or 'omniai-mistral':
+
+          `gem install omniai-openai`
+          `gem install omniai-anthropic`
+          `gem install omniai-deepseek`
+          `gem install omniai-google`
+          `gem install omniai-mistral`
+      TEXT
     end
 
     # Initialize a client by provider (e.g. 'openai'). This method attempts to require the provider.
     #
-    # @param provider [String, Symbol] required (e.g. 'anthropic', 'deepsek', 'google', 'mistral', 'openai', etc)
     #
-    # @raise [OmniAI::Error] if the provider is not defined and the gem is not installed
+    # @param provider [String, Symbol] required (e.g. 'anthropic', 'deepseek', 'google', 'mistral', 'openai', etc)
+    #
+    # @raise [OmniAI::LoadError] if the provider is not defined and the gem is not installed
     #
     # @return [OmniAI::Client]
     def self.find(provider:, **)

--- a/lib/omniai/load_error.rb
+++ b/lib/omniai/load_error.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module OmniAI
+  # An error that wraps a ::LoadError for a missing library.
+  class LoadError < Error
+  end
+end

--- a/lib/omniai/version.rb
+++ b/lib/omniai/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniAI
-  VERSION = "2.6.0"
+  VERSION = "2.7.0"
 end

--- a/spec/omniai/client_spec.rb
+++ b/spec/omniai/client_spec.rb
@@ -148,6 +148,28 @@ RSpec.describe OmniAI::Client do
     end
   end
 
+  describe ".discover" do
+    subject(:discover) { described_class.discover }
+
+    context "when find returns a client" do
+      let(:client) { instance_double(described_class) }
+
+      it "returns a client" do
+        allow(described_class).to receive(:find) { client }
+        expect(discover).to eql(client)
+        expect(described_class).to have_received(:find)
+      end
+    end
+
+    context "when find does not return a client" do
+      it "raises an error" do
+        allow(described_class).to receive(:find).and_raise(OmniAI::LoadError)
+        expect { discover }.to raise_error(OmniAI::LoadError)
+        expect(described_class).to have_received(:find).exactly(5).times
+      end
+    end
+  end
+
   describe "#api_key" do
     it { expect(client.api_key).to eq(api_key) }
   end

--- a/spec/omniai_spec.rb
+++ b/spec/omniai_spec.rb
@@ -4,4 +4,89 @@ RSpec.describe OmniAI do
   it "has a version number" do
     expect(described_class::VERSION).not_to be_nil
   end
+
+  describe ".client" do
+    subject(:client) { described_class.client(provider:) }
+
+    context "without a provider" do
+      let(:provider) { nil }
+
+      it "delegates to OmniAI::Client.discover" do
+        allow(OmniAI::Client).to receive(:discover) { instance_double(OmniAI::Client) }
+        expect(client).not_to be_nil
+        expect(OmniAI::Client).to have_received(:discover)
+      end
+    end
+
+    context "with a provider" do
+      let(:provider) { :openai }
+
+      it "delegates to OmniAI::Client.find" do
+        allow(OmniAI::Client).to receive(:find) { instance_double(OmniAI::Client) }
+        expect(client).not_to be_nil
+        expect(OmniAI::Client).to have_received(:find).with(provider:)
+      end
+    end
+  end
+
+  describe ".chat" do
+    subject(:chat) { described_class.chat(prompt, model:) }
+
+    let(:client) { instance_double(OmniAI::Client) }
+    let(:prompt) { "What is the capital of Canada?" }
+    let(:model) { "davinci" }
+
+    it "delegates to 'OmniAI::Client#chat'" do
+      allow(OmniAI::Client).to receive(:discover).and_return(client)
+      allow(client).to receive(:chat)
+      chat
+      expect(client).to have_received(:chat).with(prompt, model:)
+    end
+  end
+
+  describe ".transcribe" do
+    subject(:transcribe) { described_class.transcribe(io, model:) }
+
+    let(:client) { instance_double(OmniAI::Client) }
+    let(:io) { instance_double(IO) }
+    let(:model) { "davinci" }
+
+    it "delegates to 'OmniAI::Client#transcribe'" do
+      allow(OmniAI::Client).to receive(:discover).and_return(client)
+      allow(client).to receive(:transcribe)
+      transcribe
+      expect(client).to have_received(:transcribe).with(io, model:)
+    end
+  end
+
+  describe ".speak" do
+    subject(:speak) { described_class.speak(input, model:, voice:) }
+
+    let(:client) { instance_double(OmniAI::Client) }
+    let(:input) { "Sally sells seashells by the seashore." }
+    let(:model) { "davinci" }
+    let(:voice) { "human" }
+
+    it "delegates to 'OmniAI::Client#speak'" do
+      allow(OmniAI::Client).to receive(:discover).and_return(client)
+      allow(client).to receive(:speak)
+      speak
+      expect(client).to have_received(:speak).with(input, model:, voice:)
+    end
+  end
+
+  describe ".embed" do
+    subject(:embed) { described_class.embed(input, model:) }
+
+    let(:client) { instance_double(OmniAI::Client) }
+    let(:input) { "Sally sells seashells by the seashore." }
+    let(:model) { "davinci" }
+
+    it "delegates to 'OmniAI::Client#embed'" do
+      allow(OmniAI::Client).to receive(:discover).and_return(client)
+      allow(client).to receive(:embed)
+      embed
+      expect(client).to have_received(:embed).with(input, model:)
+    end
+  end
 end


### PR DESCRIPTION
This shorter form enables all the functions of `chat` / `speak` / `transcribe` / `embed` without needing to require and initialize a client. It "discovers" a client (tries loading `openai` then `anthropic` then `google` then `mistral` then `deepseek`). This order is somewhat arbitrary, but also reflects the full capabilities of the APIs.

## Examples of OmniAI.chat

```ruby
require 'omniai'
puts OmniAI.chat('What is the Capital of Spain?').text
```

```
The capital of Spain is **Madrid**.
```

```ruby
require 'omniai'
OmniAI.chat(stream: $stdout) do |prompt|
  prompt.system('Answer only in French')
  prompt.user('How many people live in Canada?')
end
```

```
En 2024, la population du Canada est d’environ 40 millions d’habitants.
```

## Example of OmniAI.speak

```ruby
require 'omniai'
File.open("audio.wav", "wb") do |file|
  OmniAI.speak("Sally sells seashells by the seashore.") do |chunk|
    file << chunk
  end
end
```

## Example of OmniAI.transcribe

```ruby
require 'omniai'
File.open("audio.wav", "rb") do |file|
  puts OmniAI.transcribe(file).text
end
```

```
Sally sells seashells by the seashore.
```

## Example of OmniAI.embed

```ruby
require 'omniai'
OmniAI.embed("Sally sells seashells by the seashore.").embedding # [...]
```