### PR TITLE
Fix a small typo

### DIFF
--- a/lib/omniai/client.rb
+++ b/lib/omniai/client.rb
@@ -117,7 +117,7 @@ module OmniAI
       end
 
       raise LoadError, <<~TEXT
-        Please rune one of the following commands to install a provider specific gem:
+        Please run one of the following commands to install a provider specific gem:
 
           `gem install omniai-openai`
           `gem install omniai-anthropic`


### PR DESCRIPTION
Fix a small typo: `rune` should be `run` :slightly_smiling_face: 