### PR TITLE
This skips running code climate if no ENV is set

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,15 @@ commands:
   codeclimate:
     steps:
       - run: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-$CC_TEST_REPORTER_VERSION > ./cc
-          chmod +x ./cc
-          ./cc format-coverage -t simplecov coverage/coverage.json
-          ./cc upload-coverage
-          rm ./cc
+          if [ -n "$CC_TEST_REPORTER_ID" ] && [ -n "$CC_TEST_REPORTER_VERSION" ]; then
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-$CC_TEST_REPORTER_VERSION > ./cc
+            chmod +x ./cc
+            ./cc format-coverage -t simplecov coverage/coverage.json
+            ./cc upload-coverage
+            rm ./cc
+          else
+            echo "[SKIPPING] codeclimate"
+          fi
 
 orbs:
   ruby: circleci/ruby@2.1.3


### PR DESCRIPTION
On branched PRs the env variables are not provided via CircleCI. This is probably for security reasons, but it means that the codeclimate build step fails.