### PR TITLE
Ensure `base64` is Required

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     omniai (2.8.1)
+      base64
       event_stream_parser
       http
       logger

--- a/lib/omniai.rb
+++ b/lib/omniai.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "base64"
 require "logger"
 require "event_stream_parser"
 require "http"

--- a/omniai.gemspec
+++ b/omniai.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "base64"
   spec.add_dependency "event_stream_parser"
   spec.add_dependency "http"
   spec.add_dependency "logger"


### PR DESCRIPTION
Future versions of ruby do not define `base64`. It currently gets loaded as a side effect of HTTP.rb. This fixes to mark as a required dependency.