### PR TITLE
Support `verbose_json` Format

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai (2.8.2)
+    omniai (2.8.3)
       base64
       event_stream_parser
       http

--- a/examples/speech_to_text
+++ b/examples/speech_to_text
@@ -6,5 +6,8 @@ require "omniai/openai"
 client = OmniAI::OpenAI::Client.new
 
 File.open(File.join(__dir__, "files/audio.wav"), "rb") do |file|
-  puts client.transcribe(file).text
+  transcription = client.transcribe(file, format: OmniAI::Transcribe::Format::VERBOSE_JSON)
+  puts "Duration: #{transcription.duration}"
+  puts "Language: #{transcription.language}"
+  puts "Text: #{transcription.text}"
 end

--- a/lib/omniai/client.rb
+++ b/lib/omniai/client.rb
@@ -207,7 +207,7 @@ module OmniAI
     # @param language [String, nil] optional
     # @param prompt [String, nil] optional
     # @param temperature [Float, nil] optional
-    # @param format [Symbol] :text, :srt, :vtt, or :json (default)
+    # @param format [String] 'text', 'srt', 'vtt', 'json' (default), or 'verbose_json'
     #
     # @return [OmniAI::Transcribe::Transcription]
     def transcribe(io, model:, language: nil, prompt: nil, temperature: nil, format: nil)

--- a/lib/omniai/transcribe/transcription.rb
+++ b/lib/omniai/transcribe/transcription.rb
@@ -16,18 +16,59 @@ module OmniAI
       #   @return [String]
       attr_accessor :format
 
+      # @!attribute [rw] duration
+      #   @return [Float, nil]
+      attr_accessor :duration
+
+      # @!attribute [rw] segments
+      #   @return [Array<Hash>, nil]
+      attr_accessor :segments
+
+      # @!attribute [rw] language
+      #   @return [String, nil]
+      attr_accessor :language
+
+      # @param data [Hash, String]
+      # @param model [String]
+      # @param format [String]
+      #
+      # @return [OmniAI::Transcribe::Transcription]
+      def self.parse(data:, model:, format:)
+        data = { "text" => data } if data.is_a?(String)
+
+        text = data["text"]
+        duration = data["duration"]
+        segments = data["segments"]
+        language = data["language"]
+
+        new(text:, model:, format:, duration:, segments:, language:)
+      end
+
       # @param text [String]
       # @param model [String]
       # @param format [String]
-      def initialize(text:, model:, format:)
+      # @param duration [Float, nil]
+      # @param segments [Array, nil]
+      # @param language [String, nil]
+      def initialize(text:, model:, format:, duration: nil, segments: nil, language: nil)
         @text = text
         @model = model
         @format = format
+        @duration = duration
+        @segments = segments
+        @language = language
       end
 
       # @return [String]
       def inspect
-        "#<#{self.class} text=#{text.inspect}>"
+        attrs = [
+          ("text=#{@text.inspect}" if @text),
+          ("model=#{@model.inspect}" if @model),
+          ("format=#{@format.inspect}" if @format),
+          ("duration=#{@duration.inspect}" if @duration),
+        ].compact.join(" ")
+
+        "#<#{self.class} #{attrs}>"
       end
     end
   end

--- a/lib/omniai/version.rb
+++ b/lib/omniai/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniAI
-  VERSION = "2.8.2"
+  VERSION = "2.8.3"
 end

--- a/spec/factories/transcribe/transcription.rb
+++ b/spec/factories/transcribe/transcription.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :transcribe_transcription, class: "OmniAI::Transcribe::Transcription" do
     initialize_with { new(**attributes) }
 
-    text { "Sally sells sea shells by the sea shore." }
+    text { "Hi!" }
     model { "whisper" }
     format { "text" }
   end

--- a/spec/omniai/transcribe/transcription_spec.rb
+++ b/spec/omniai/transcribe/transcription_spec.rb
@@ -1,7 +1,44 @@
 # frozen_string_literal: true
 
 RSpec.describe OmniAI::Transcribe::Transcription do
-  subject(:transcription) { described_class.new(text: "Hi!", model: "whisper", format: "text") }
+  subject(:transcription) { build(:transcribe_transcription) }
+
+  describe ".parse" do
+    subject(:parse) { described_class.parse(data:, model:, format:) }
+
+    context "with text data" do
+      let(:data) { "Hi!" }
+      let(:model) { "whisper" }
+      let(:format) { "text" }
+
+      it { expect(parse.text).to eq("Hi!") }
+      it { expect(parse.model).to eq("whisper") }
+      it { expect(parse.format).to eq("text") }
+      it { expect(parse.duration).to be_nil }
+      it { expect(parse.language).to be_nil }
+      it { expect(parse.segments).to be_nil }
+    end
+
+    context "with hash data" do
+      let(:data) do
+        {
+          "text" => "Hi!",
+          "duration" => 5.0,
+          "segments" => [],
+          "language" => "en",
+        }
+      end
+      let(:model) { "whisper" }
+      let(:format) { "verbose_json" }
+
+      it { expect(parse.text).to eq("Hi!") }
+      it { expect(parse.model).to eq("whisper") }
+      it { expect(parse.format).to eq("verbose_json") }
+      it { expect(parse.duration).to eq(5.0) }
+      it { expect(parse.language).to eq("en") }
+      it { expect(parse.segments).to eq([]) }
+    end
+  end
 
   describe "#text" do
     it { expect(transcription.text).to eq("Hi!") }
@@ -16,6 +53,8 @@ RSpec.describe OmniAI::Transcribe::Transcription do
   end
 
   describe "#inspect" do
-    it { expect(transcription.inspect).to eq('#<OmniAI::Transcribe::Transcription text="Hi!">') }
+    subject(:inspect) { transcription.inspect }
+
+    it { expect(inspect).to eq('#<OmniAI::Transcribe::Transcription text="Hi!" model="whisper" format="text">') }
   end
 end


### PR DESCRIPTION
## Context

This change supports setting format to `verbose_json` giving the following additional properties:
    
1. `duration`
2. `language`
3. `segments`
    
## Usage:
    
```ruby
require "omniai/openai"

client = OmniAI::OpenAI::Client.new

File.open(File.join(__dir__, "files/audio.wav"), "rb") do |file|
  transcription = client.transcribe(file, format: OmniAI::Transcribe::Format::VERBOSE_JSON)
  puts "Duration: #{transcription.duration}"
  puts "Language: #{transcription.language}"
  puts "Text: #{transcription.text}"
end
```
