### PR TITLE
Document custom OpenAI-compatible hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,19 @@ require 'omniai/openai'
 client = OmniAI::OpenAI::Client.new
 ```
 
+OpenAI-compatible gateways can be configured by passing a custom host. This keeps
+normal OpenAI usage unchanged while allowing private gateways, local model
+servers, or governed endpoints such as Tuning Engines:
+
+```ruby
+require 'omniai/openai'
+
+client = OmniAI::OpenAI::Client.new(
+  api_key: ENV.fetch('OPENAI_API_KEY'),
+  host: ENV.fetch('OPENAI_HOST', 'https://api.openai.com')
+)
+```
+
 #### Usage with LocalAI
 
 LocalAI support is offered through [OmniAI::OpenAI](https://github.com/ksylvest/omniai-openai):


### PR DESCRIPTION
## Summary

- adds a short OpenAI-compatible gateway example using the existing `host:` option
- keeps normal OpenAI behavior unchanged by default
- clarifies that the same path works for private gateways, local model servers, or governed endpoints

## Notes

Docs-only change. No code changes.
