### PR TITLE
Add normalized finish_reason value object to Chat::Response and Chat::Choice

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai (3.6.0)
+    omniai (3.7.0)
       base64
       event_stream_parser
       http (~> 5)

--- a/lib/omniai/chat/choice.rb
+++ b/lib/omniai/chat/choice.rb
@@ -16,11 +16,18 @@ module OmniAI
       #   @return [Message]
       attr_accessor :message
 
+      # @!attribute [rw] finish_reason
+      #   @return [FinishReason, nil] the normalized reason generation stopped (carrying both `#reason` and the
+      #     verbatim provider `#value`), or `nil` when absent.
+      attr_accessor :finish_reason
+
       # @param message [Message]
       # @param index [Integer]
-      def initialize(message:, index: DEFAULT_INDEX)
+      # @param finish_reason [FinishReason, nil]
+      def initialize(message:, index: DEFAULT_INDEX, finish_reason: nil)
         @message = message
         @index = index
+        @finish_reason = finish_reason
       end
 
       # @return [String]
@@ -39,7 +46,7 @@ module OmniAI
         index = data["index"] || DEFAULT_INDEX
         message = Message.deserialize(data["message"] || data["delta"], context:)
 
-        new(message:, index:)
+        new(message:, index:, finish_reason: FinishReason.deserialize(data["finish_reason"]))
       end
 
       # @param context [OmniAI::Context] optional

--- a/lib/omniai/chat/finish_reason.rb
+++ b/lib/omniai/chat/finish_reason.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module OmniAI
+  class Chat
+    # A normalized, provider-agnostic reason a generation stopped, paired with the verbatim provider value.
+    #
+    # `#reason` is one of the canonical symbols ({REASONS}) for branching/alerting; `#value` is the raw provider
+    # token (e.g. "RECITATION", "end_turn", "stop"), preserved verbatim — including when the reason normalizes to
+    # `:other`. Each provider maps its own vocabulary onto a reason in its deserializer; the verbatim value is never
+    # discarded, so consumers keep provider granularity without digging the provider-specific response `data`.
+    class FinishReason
+      # A natural stopping point was reached.
+      STOP = :stop
+
+      # The token budget (requested max tokens or the model's context window) was reached.
+      LENGTH = :length
+
+      # The model is requesting a tool / function call.
+      TOOL_CALL = :tool_call
+
+      # The provider deliberately suppressed or blocked output (safety, policy, recitation, unsupported language).
+      FILTER = :filter
+
+      # A value was present but does not map to a known category (forward-compatible fallback).
+      OTHER = :other
+
+      # The canonical normalized reasons.
+      REASONS = %i[stop length tool_call filter other].freeze
+
+      # The Chat Completions `finish_reason` vocabulary (originated by OpenAI; also emitted by Mistral and
+      # OpenAI-compatible gateways). Applied by the base `Choice.deserialize` path, which models that schema.
+      CHAT_COMPLETIONS = {
+        "stop" => STOP,
+        "length" => LENGTH,
+        "tool_calls" => TOOL_CALL,
+        "function_call" => TOOL_CALL,
+        "content_filter" => FILTER,
+      }.freeze
+
+      # @!attribute [r] reason
+      #   @return [Symbol] one of {REASONS}
+      attr_reader :reason
+
+      # @!attribute [r] value
+      #   @return [String] the verbatim provider token
+      attr_reader :value
+
+      # Normalizes a raw provider value through a mapping table into a FinishReason.
+      #
+      # - `nil` in → `nil` out (absence is not the same as unrecognized).
+      # - otherwise → a FinishReason whose `reason` is the table's mapping (or `:other` when unmapped) and whose
+      #   `value` is the raw token, preserved verbatim — always, including on `:other`.
+      #
+      # @param value [String, nil] the raw provider value
+      # @param table [Hash{String => Symbol}] the provider's mapping table (defaults to the Chat Completions vocabulary)
+      #
+      # @return [FinishReason, nil]
+      def self.deserialize(value, table: CHAT_COMPLETIONS)
+        return if value.nil?
+
+        new(reason: table.fetch(value, OTHER), value:)
+      end
+
+      # @param reason [Symbol] one of {REASONS}
+      # @param value [String] the verbatim provider token
+      def initialize(reason:, value:)
+        @reason = reason
+        @value = value
+      end
+
+      # @return [String]
+      def inspect
+        "#<#{self.class.name} reason=#{reason.inspect} value=#{value.inspect}>"
+      end
+
+      # @return [Boolean]
+      def stop?
+        reason == STOP
+      end
+
+      # @return [Boolean]
+      def length?
+        reason == LENGTH
+      end
+
+      # @return [Boolean]
+      def tool_call?
+        reason == TOOL_CALL
+      end
+
+      # @return [Boolean]
+      def filter?
+        reason == FILTER
+      end
+
+      # @return [Boolean]
+      def other?
+        reason == OTHER
+      end
+    end
+  end
+end

--- a/lib/omniai/chat/response.rb
+++ b/lib/omniai/chat/response.rb
@@ -23,11 +23,28 @@ module OmniAI
       # @param data [Hash]
       # @param choices [Array<Choice>]
       # @param usage [Usage, nil]
-      def initialize(data:, choices: [], usage: nil)
+      # @param finish_reason [FinishReason, nil] an optional response-level finish reason (used by providers that
+      #   expose it at the response level, e.g. OpenAI's Responses API); when omitted, `#finish_reason` falls back to
+      #   the first choice's finish reason.
+      def initialize(data:, choices: [], usage: nil, finish_reason: nil)
         @data = data
         @choices = choices
         @usage = usage
+        @finish_reason = finish_reason
       end
+
+      # The normalized {FinishReason} for the final turn (carrying both `#reason` and the verbatim provider `#value`),
+      # or `nil` when absent. Some providers (e.g. OpenAI's Responses API) expose this at the response level; most
+      # expose it per-choice. Prefers an explicit response-level value, then falls back to the first choice. Reflects
+      # this response only (the final turn) — it is not aggregated across the parent chain, unlike {#total_usage}.
+      #
+      # @return [FinishReason, nil]
+      def finish_reason
+        @finish_reason || @choices.first&.finish_reason
+      end
+
+      # @!attribute [w] finish_reason
+      attr_writer :finish_reason
 
       # @return [String]
       def inspect

--- a/lib/omniai/version.rb
+++ b/lib/omniai/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniAI
-  VERSION = "3.6.0"
+  VERSION = "3.7.0"
 end

--- a/spec/factories/chat/choice.rb
+++ b/spec/factories/chat/choice.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
 
     message factory: :chat_message
     index { 0 }
+    finish_reason { nil }
   end
 end

--- a/spec/factories/chat/response.rb
+++ b/spec/factories/chat/response.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     usage factory: :chat_usage
     choices { [] }
     data { {} }
+    finish_reason { nil }
   end
 end

--- a/spec/omniai/chat/choice_spec.rb
+++ b/spec/omniai/chat/choice_spec.rb
@@ -17,10 +17,59 @@ RSpec.describe OmniAI::Chat::Choice do
     it { expect(choice.message).to eql(message) }
   end
 
+  describe "#finish_reason" do
+    context "when set" do
+      subject(:choice) { build(:chat_choice, message:, index: 0, finish_reason:) }
+
+      let(:finish_reason) { OmniAI::Chat::FinishReason.new(reason: :stop, value: "stop") }
+
+      it { expect(choice.finish_reason).to eql(finish_reason) }
+    end
+
+    context "when unset" do
+      it { expect(choice.finish_reason).to be_nil }
+    end
+  end
+
   describe ".deserialize" do
     subject(:deserialize) { described_class.deserialize(data, context:) }
 
     let(:data) { { "index" => 0, "message" => { "role" => "user", "content" => "Hello!" } } }
+
+    context "with a known finish_reason in the data (base / OpenAI-compatible path)" do
+      let(:context) { OmniAI::Context.build }
+      let(:data) do
+        { "index" => 0, "message" => { "role" => "user", "content" => "Hello!" }, "finish_reason" => "length" }
+      end
+
+      it "normalizes the reason" do
+        expect(deserialize.finish_reason.reason).to eq(:length)
+      end
+
+      it "preserves the verbatim value" do
+        expect(deserialize.finish_reason.value).to eq("length")
+      end
+    end
+
+    context "with an unrecognized finish_reason in the data" do
+      let(:context) { OmniAI::Context.build }
+      let(:data) do
+        { "index" => 0, "message" => { "role" => "user", "content" => "Hello!" }, "finish_reason" => "supernova" }
+      end
+
+      it "maps the reason to :other but preserves the verbatim value" do
+        expect(deserialize.finish_reason).to be_other
+        expect(deserialize.finish_reason.value).to eq("supernova")
+      end
+    end
+
+    context "with no finish_reason in the data" do
+      let(:context) { OmniAI::Context.build }
+
+      it "leaves it nil (absence is not :other)" do
+        expect(deserialize.finish_reason).to be_nil
+      end
+    end
 
     context "with a deserializer" do
       let(:context) do

--- a/spec/omniai/chat/finish_reason_spec.rb
+++ b/spec/omniai/chat/finish_reason_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+RSpec.describe OmniAI::Chat::FinishReason do
+  describe ".deserialize" do
+    let(:table) { { "stop" => :stop, "length" => :length } }
+
+    context "when the value is nil" do
+      it "returns nil (absence is not :other)" do
+        expect(described_class.deserialize(nil, table:)).to be_nil
+      end
+    end
+
+    context "when the value is in the table" do
+      subject(:finish_reason) { described_class.deserialize("length", table:) }
+
+      it { expect(finish_reason).to be_a(described_class) }
+      it { expect(finish_reason.reason).to eq(:length) }
+      it { expect(finish_reason.value).to eq("length") }
+    end
+
+    context "when the value is present but not in the table" do
+      subject(:finish_reason) { described_class.deserialize("supernova", table:) }
+
+      it "normalizes the reason to :other" do
+        expect(finish_reason.reason).to eq(:other)
+      end
+
+      it "preserves the verbatim value even on :other" do
+        expect(finish_reason.value).to eq("supernova")
+      end
+    end
+
+    context "when no table is given" do
+      it "defaults to the Chat Completions vocabulary" do
+        expect(described_class.deserialize("tool_calls").reason).to eq(:tool_call)
+      end
+    end
+  end
+
+  describe "predicates" do
+    it { expect(described_class.new(reason: :stop, value: "stop")).to be_stop }
+    it { expect(described_class.new(reason: :length, value: "MAX_TOKENS")).to be_length }
+    it { expect(described_class.new(reason: :tool_call, value: "tool_use")).to be_tool_call }
+    it { expect(described_class.new(reason: :filter, value: "RECITATION")).to be_filter }
+    it { expect(described_class.new(reason: :other, value: "weird")).to be_other }
+    it { expect(described_class.new(reason: :stop, value: "stop")).not_to be_filter }
+  end
+
+  describe "CHAT_COMPLETIONS table" do
+    it "maps the Chat Completions vocabulary" do
+      expect(described_class::CHAT_COMPLETIONS).to eq({
+        "stop" => :stop,
+        "length" => :length,
+        "tool_calls" => :tool_call,
+        "function_call" => :tool_call,
+        "content_filter" => :filter,
+      })
+    end
+  end
+end

--- a/spec/omniai/chat/response_spec.rb
+++ b/spec/omniai/chat/response_spec.rb
@@ -14,6 +14,38 @@ RSpec.describe OmniAI::Chat::Response do
     }
   end
 
+  describe "#finish_reason" do
+    let(:length) { OmniAI::Chat::FinishReason.new(reason: :length, value: "max_output_tokens") }
+    let(:filter) { OmniAI::Chat::FinishReason.new(reason: :filter, value: "content_filter") }
+    let(:stop) { OmniAI::Chat::FinishReason.new(reason: :stop, value: "stop") }
+
+    context "when set explicitly on the response (e.g. OpenAI Responses status)" do
+      subject(:response) { build(:chat_response, choices:, usage:, finish_reason: length) }
+
+      it { expect(response.finish_reason).to eql(length) }
+    end
+
+    context "when only the choice carries it (e.g. OpenAI/Mistral/Anthropic/Google)" do
+      let(:choice) { build(:chat_choice, message:, finish_reason: stop) }
+
+      it "falls back to the first choice's finish_reason" do
+        expect(response.finish_reason).to eql(stop)
+      end
+    end
+
+    context "when an explicit response value is present it wins over the choice" do
+      subject(:response) { build(:chat_response, choices:, usage:, finish_reason: filter) }
+
+      let(:choice) { build(:chat_choice, message:, finish_reason: stop) }
+
+      it { expect(response.finish_reason.reason).to eq(:filter) }
+    end
+
+    context "when neither is set" do
+      it { expect(response.finish_reason).to be_nil }
+    end
+  end
+
   describe ".deserialize" do
     subject(:deserialize) { described_class.deserialize(data, context:) }
 


### PR DESCRIPTION
## Summary

Exposes a normalized, provider-agnostic reason a generation stopped on `OmniAI::Chat::Response` and `OmniAI::Chat::Choice`, as a **`FinishReason` value object**. Today `Response` exposes `text`/`usage`/`data` but no way to learn *why* a turn ended — so a token cutoff or a refusal returns a "successful" response with blank text and no diagnosable signal.

This base PR adds the contract; the provider gems map their own vocabulary onto it in companion PRs.

## `OmniAI::Chat::FinishReason`

A value object — modeled on the existing `Usage` value object — carrying **both** a normalized reason and the verbatim provider token:

- **`#reason`** — one of `REASONS` (`:stop`, `:length`, `:tool_call`, `:filter`, `:other`) for branching/alerting.
- **`#value`** — the raw provider token (e.g. `"RECITATION"`, `"end_turn"`, `"stop"`), preserved **always**, including when the reason normalizes to `:other`. This keeps provider granularity (e.g. Google `RECITATION` vs `SAFETY`) without consumers having to dig the provider-specific response `data`.
- **`.deserialize(value, table: CHAT_COMPLETIONS)`** — follows the gem's `.deserialize` idiom. `nil` → `nil` (absence ≠ unrecognized); otherwise a `FinishReason` whose `reason` is the table mapping (or `:other` when unmapped) and whose `value` is the raw token. **Never raises.** The table defaults to the Chat Completions vocabulary (so the base `Choice.deserialize` path and gateways normalize for free).
- **Predicates** — `stop?`/`length?`/`tool_call?`/`filter?`/`other?` (the house predicate idiom, cf. `Message#system?` / `Media#image?`).

The surface deliberately mirrors `Usage`: `attr_reader` + `initialize` + `inspect` + `self.deserialize` + predicates — **no custom `==`/`eql?`/`hash`/`to_sym`/`to_s`** (no other class in the gem defines those; they'd be an invented pattern). Consumers compare by attribute, exactly like `Usage`:

```ruby
response.finish_reason&.length?        # => true on a token cutoff (any provider)
response.finish_reason&.reason == :filter   # => safety / policy / recitation / language block
response.finish_reason&.value          # => "RECITATION"  (verbatim, full granularity)
```

## Placement & contract

- `Choice#finish_reason` / `Response#finish_reason` hold a `FinishReason` (or `nil`). `Response#finish_reason` prefers an explicit response-level value (e.g. OpenAI's Responses API) and otherwise falls back to the first choice — one unbranched accessor.
- The base API contains no provider names (the `CHAT_COMPLETIONS` table is schema vocabulary, originated by OpenAI but shared by Mistral / OpenAI-compatible gateways).
- **Final turn only** — not aggregated across the parent chain, unlike `#total_usage`.
- **Read-only** — not added to `serialize` (a response-output property, never sent to a provider).

## Tests

TDD. `461 examples, 0 failures`; rubocop clean. Releases as **omniai 3.7.0** (additive, minor).
