### PR TITLE
Fix http 6 nil response when a logger is configured

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai (3.7.0)
+    omniai (3.7.1)
       base64
       event_stream_parser
       http (>= 5, < 7)
@@ -125,9 +125,10 @@ GEM
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
-    rubocop-rspec (3.9.0)
+    rubocop-rspec (3.10.2)
       lint_roller (~> 1.1)
-      rubocop (~> 1.81)
+      regexp_parser (>= 2.0)
+      rubocop (~> 1.86, >= 1.86.2)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     simplecov (0.22.0)

--- a/lib/omniai/instrumentation.rb
+++ b/lib/omniai/instrumentation.rb
@@ -8,12 +8,23 @@ module OmniAI
       @logger = logger
     end
 
-    # ActiveSupport::Notifications-compatible instrument. On http 6 the
-    # instrumentation feature drives the whole request through `around_request`
-    # → `instrument(name, ...) { ... }` and uses the block's return value as the
-    # response, so the block MUST be yielded and its result returned (otherwise
-    # the response is lost as `nil`). On http 5 this is only ever called without
-    # a block for the start/error events (logging is done via #start / #finish).
+    # ActiveSupport::Notifications-compatible instrument.
+    #
+    # On http 6 the instrumentation feature drives every request through
+    # `around_request`, which (per http's own feature docs) "emits two events on
+    # every request: `start_request.http` before the request is made [and]
+    # `request.http` after the response is received". Both are delivered here as
+    # `instrument(name) { ... }` calls: the start event carries an empty block,
+    # and the request event's block wraps the exchange and returns the response.
+    # The block of the request event MUST be yielded and its value returned,
+    # otherwise the response is lost as `nil` (http uses the return value as the
+    # response). We log the request on the start event and the response on the
+    # request event. The event namespace is caller-configurable (the names are
+    # `start_request.#{namespace}` / `request.#{namespace}`), so #start_event?
+    # prefix-matches rather than comparing the full name.
+    #
+    # On http 5 this is only ever called without a block (for the start and
+    # error events); request/response logging there happens via #start / #finish.
     #
     # @param name [String]
     # @param payload [Hash]
@@ -26,7 +37,7 @@ module OmniAI
 
       return unless block_given?
 
-      if name.to_s.start_with?("start_")
+      if start_event?(name)
         log_request(payload[:request])
         yield payload
       else
@@ -49,6 +60,14 @@ module OmniAI
     end
 
   private
+
+    # @param name [String] the http instrumentation event name, e.g.
+    #   "start_request.http" (pre-flight) or "request.http" (the exchange).
+    #
+    # @return [Boolean] true for the pre-flight "start_..." event
+    def start_event?(name)
+      name.to_s.start_with?("start_")
+    end
 
     # @param request [HTTP::Request, nil]
     def log_request(request)

--- a/lib/omniai/instrumentation.rb
+++ b/lib/omniai/instrumentation.rb
@@ -8,27 +8,59 @@ module OmniAI
       @logger = logger
     end
 
+    # ActiveSupport::Notifications-compatible instrument. On http 6 the
+    # instrumentation feature drives the whole request through `around_request`
+    # → `instrument(name, ...) { ... }` and uses the block's return value as the
+    # response, so the block MUST be yielded and its result returned (otherwise
+    # the response is lost as `nil`). On http 5 this is only ever called without
+    # a block for the start/error events (logging is done via #start / #finish).
+    #
     # @param name [String]
     # @param payload [Hash]
+    # @option payload [HTTP::Request] :request
+    # @option payload [HTTP::Response] :response
     # @option payload [Exception] :error
     def instrument(name, payload = {})
       error = payload[:error]
-      return unless error
+      @logger.error("#{name}: #{error.message}") if error
 
-      @logger.error("#{name}: #{error.message}")
+      return unless block_given?
+
+      if name.to_s.start_with?("start_")
+        log_request(payload[:request])
+        yield payload
+      else
+        response = yield payload
+        log_response(payload[:response] || response)
+        response
+      end
     end
 
     # @param payload [Hash]
     # @option payload [HTTP::Request] :request
     def start(_, payload)
-      request = payload[:request]
-      @logger.info("#{request.verb.upcase} #{request.uri}")
+      log_request(payload[:request])
     end
 
     # @param payload [Hash]
     # @option payload [HTTP::Response] :response
     def finish(_, payload)
-      response = payload[:response]
+      log_response(payload[:response])
+    end
+
+  private
+
+    # @param request [HTTP::Request, nil]
+    def log_request(request)
+      return unless request
+
+      @logger.info("#{request.verb.upcase} #{request.uri}")
+    end
+
+    # @param response [HTTP::Response, nil]
+    def log_response(response)
+      return unless response
+
       @logger.info("#{response.status.code} #{response.status.reason}")
     end
   end

--- a/lib/omniai/version.rb
+++ b/lib/omniai/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniAI
-  VERSION = "3.7.0"
+  VERSION = "3.7.1"
 end

--- a/spec/omniai/instrumentation_spec.rb
+++ b/spec/omniai/instrumentation_spec.rb
@@ -19,6 +19,39 @@ RSpec.describe OmniAI::Instrumentation do
         expect(logger).to have_received(:error).with("Error: unknown")
       end
     end
+
+    context "with a block (http 6 around_request contract)" do
+      it "yields and returns the block's result so the response propagates" do
+        allow(logger).to receive(:info)
+        result = instrumentation.instrument("request.http", request:) { response }
+        expect(result).to eq(response)
+      end
+
+      it "logs the response for the request event" do
+        allow(logger).to receive(:info)
+        instrumentation.instrument("request.http", request:) { response }
+        expect(logger).to have_received(:info).with("200 OK")
+      end
+
+      it "logs the request for the start event and still yields" do
+        allow(logger).to receive(:info)
+        yielded = false
+        instrumentation.instrument("start_request.http", request:) { yielded = true }
+        expect(logger).to have_received(:info).with("POST /chat")
+        expect(yielded).to be(true)
+      end
+    end
+
+    context "when plugged into http's real instrumentation feature" do
+      let(:feature) { HTTP::Features::Instrumentation.new(instrumenter: instrumentation) }
+
+      it "drives around_request and returns the response (reproduces the http 6 nil bug)" do
+        skip "around_request is http 6+" unless feature.respond_to?(:around_request)
+        allow(logger).to receive(:info)
+        result = feature.around_request(request) { response }
+        expect(result).to eq(response)
+      end
+    end
   end
 
   describe "#start" do

--- a/spec/omniai/instrumentation_spec.rb
+++ b/spec/omniai/instrumentation_spec.rb
@@ -40,6 +40,15 @@ RSpec.describe OmniAI::Instrumentation do
         expect(logger).to have_received(:info).with("POST /chat")
         expect(yielded).to be(true)
       end
+
+      it "is benign for an error event with an empty block (http 6 on_error)" do
+        allow(logger).to receive(:info)
+        allow(logger).to receive(:error)
+        result = instrumentation.instrument("error.http", request:, error: StandardError.new("boom")) { nil }
+        expect(result).to be_nil
+        expect(logger).to have_received(:error).with("error.http: boom")
+        expect(logger).not_to have_received(:info)
+      end
     end
 
     context "when plugged into http's real instrumentation feature" do
@@ -50,6 +59,16 @@ RSpec.describe OmniAI::Instrumentation do
         allow(logger).to receive(:info)
         result = feature.around_request(request) { response }
         expect(result).to eq(response)
+      end
+
+      # Contract guard: drives http's REAL event names (not our own strings) so a
+      # future upstream rename of the "start_" prefix fails loudly instead of
+      # silently dropping the request log line.
+      it "logs the request line via http's real event names" do
+        skip "around_request is http 6+" unless feature.respond_to?(:around_request)
+        allow(logger).to receive(:info)
+        feature.around_request(request) { response }
+        expect(logger).to have_received(:info).with("POST /chat")
       end
     end
   end


### PR DESCRIPTION
## Summary

Fixes a runtime `NoMethodError: undefined method 'request' for nil` that occurs on **http 6** for any request made while a logger is configured (chat, streaming, transcribe — anything through the client). Found via a live failure in a downstream app; the gem's WebMock specs stayed green because they run without a logger.

## Root cause

`OmniAI::Instrumentation#instrument` ignored its block and returned `nil`.

- **http 5**'s instrumentation feature used `wrap_request` / `wrap_response` (+ `start` / `finish`), so the response never flowed through `#instrument` — the missing yield was harmless.
- **http 6** rewrote the feature to drive the entire exchange through `around_request → instrumenter.instrument(name) { ...run request... }` and uses **the block's return value as the response**.

Because our instrumenter never yielded the block, `instrument` returned `nil` → `perform_exchange` returned `nil` → `perform_once` called `res.request` on `nil` → crash. The instrumentation feature only activates when a logger is set, which is why a real app (logger configured) crashed while WebMock specs (no logger) passed.

Backtrace seen downstream:
```
NoMethodError: undefined method 'request' for nil
  http-6.0.3/lib/http/client.rb:120  perform_once   <- perform_exchange returned nil
  omniai-google/.../chat.rb           request!       <- streaming POST
  omniai/lib/omniai/client.rb         connection     <- HTTP.persistent(@host)
```

## Fix

Make `OmniAI::Instrumentation` a proper ActiveSupport::Notifications-compatible instrumenter (which the http docs state the feature expects): `#instrument` now yields its block and returns the result (the response). Request/response logging is routed through nil-safe `#log_request` / `#log_response` helpers, keeping `#start` / `#finish` for the http 5 path. Behavior on http 5 is unchanged.

## Verification

- New unit test drives http's **real** `HTTP::Features::Instrumentation#around_request` through the instrumenter and asserts the response propagates (reproduces the http 6 nil; runs in CI since the lock is on http 6.0.3).
- Live (non-WebMock) network check: `HTTP.persistent` + instrumentation(logger) + POST → `200 OK` on **http 6.0.3 and http 5.3.1**; the old instrumenter crashes on the same path with the exact backtrace above.
- Full suite: 465 examples, 0 failures. Rubocop clean.

No constraint change — `http ">= 5", "< 7"` keeps working on both. Patch release **3.7.1**.

## Changes
- `lib/omniai/instrumentation.rb` — yield + return the response; nil-safe logging helpers
- `spec/omniai/instrumentation_spec.rb` — block-contract + real-feature tests
- `lib/omniai/version.rb` — 3.7.0 → 3.7.1