### PR TITLE
Add Usage#thinking_tokens and stop discarding provider-reported totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,4 +25,8 @@
 
   Known limitation: Anthropic reports no total at all, so its contribution is always the derived `input + output`, which excludes `cache_creation_input_tokens` and `cache_read_input_tokens`. An aggregate spanning Anthropic responses therefore understates cache-heavy conversations.
 
+### Upgrading
+
+- **Verified doubles of `OmniAI::Chat::Usage` need `thinking_tokens` stubbed.** `Response#total_usage` now reads the new attribute, so an `instance_double(OmniAI::Chat::Usage, input_tokens:, output_tokens:, total_tokens:)` raises on the unstubbed method. RSpec is behaving correctly — the double is verified against the real class — but it surfaces at upgrade time in specs rather than in application code. Add `thinking_tokens:` to affected doubles; `nil` is a valid value and matches a provider that reports no breakdown.
+
 Earlier changes are recorded in the GitHub releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,20 @@
 
 ### Added
 
-- `OmniAI::Chat::Usage#thinking_tokens` reports the subset of `output_tokens` a provider attributes to internal reasoning. It defaults to `nil`, which means the provider reported no breakdown — deliberately distinct from `0`, which means the provider reported that no reasoning occurred. The generic deserializer populates it from the breakdown each provider already sends alongside its output count: `output_tokens_details.thinking_tokens` (Anthropic) or `completion_tokens_details.reasoning_tokens` (OpenAI). `#serialize` emits the key only when a value is present, so payloads for providers that report no breakdown are unchanged.
+- `OmniAI::Chat::Usage#thinking_tokens` reports the subset of `output_tokens` a provider attributes to internal reasoning. It defaults to `nil`, which means the provider reported no breakdown — deliberately distinct from `0`, which means the provider reported that no reasoning occurred. `#serialize` emits the key only when a value is present, so payloads for providers that report no breakdown are unchanged.
 
   `thinking_tokens` is always a *subset* of `output_tokens`, never an addition to it. Providers that fold reasoning into their output count keep that count as-is and gain only the breakdown; providers that report reasoning separately have it added into `output_tokens` so the field means the same thing everywhere.
+
+  **This class reads only its own `thinking_tokens` key.** Each provider's own vocabulary is read by that provider's `:usage` deserializer, so the field is populated only by provider gems that ship one:
+
+  | Provider | Populated | Read from |
+  | --- | --- | --- |
+  | omniai-google >= 3.12 | yes | `thoughtsTokenCount` |
+  | omniai-anthropic >= 3.6 | yes | `usage.output_tokens_details.thinking_tokens` |
+  | omniai-openai >= 3.2 | yes | `usage.output_tokens_details.reasoning_tokens` (Responses API) |
+  | omniai-mistral | no | no breakdown reported |
+
+  Against an older provider gem, or one not listed, `thinking_tokens` is `nil`. That is the same value it held before this release, so nothing regresses — but do not read `nil` as "no reasoning occurred".
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## 3.8.0
+
+### Added
+
+- `OmniAI::Chat::Usage#thinking_tokens` reports the subset of `output_tokens` a provider attributes to internal reasoning. It defaults to `nil`, which means the provider reported no breakdown — deliberately distinct from `0`, which means the provider reported that no reasoning occurred. The generic deserializer populates it from the breakdown each provider already sends alongside its output count: `output_tokens_details.thinking_tokens` (Anthropic) or `completion_tokens_details.reasoning_tokens` (OpenAI). `#serialize` emits the key only when a value is present, so payloads for providers that report no breakdown are unchanged.
+
+  `thinking_tokens` is always a *subset* of `output_tokens`, never an addition to it. Providers that fold reasoning into their output count keep that count as-is and gain only the breakdown; providers that report reasoning separately have it added into `output_tokens` so the field means the same thing everywhere.
+
+### Fixed
+
+- `OmniAI::Chat::Response#total_usage` now sums each response's provider-reported `total_tokens` and falls back to `input + output` only where a provider reported none. It previously recomputed the total unconditionally, which discarded any tokens a provider counts as neither input nor output — Google's `totalTokenCount` includes thinking tokens, so an aggregate could report a smaller total than the individual responses it summed. `thinking_tokens` is aggregated alongside, and stays `nil` when no response in the chain reported one.
+
+  Known limitation: Anthropic reports no total at all, so its contribution is always the derived `input + output`, which excludes `cache_creation_input_tokens` and `cache_read_input_tokens`. An aggregate spanning Anthropic responses therefore understates cache-heavy conversations.
+
+Earlier changes are recorded in the GitHub releases.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai (3.7.1)
+    omniai (3.8.0)
       base64
       event_stream_parser
       http (>= 5, < 7)

--- a/README.md
+++ b/README.md
@@ -578,6 +578,30 @@ client.chat("Solve this step by step: What is 123 * 456?", thinking: true, strea
 | Google | `thinking: true` | Requires Gemini 2.0+ with thinking enabled |
 | OpenAI | `thinking: true` or `thinking: { effort: "high" }` | Requires o1/o3 models |
 
+#### Thinking Token Accounting
+
+Reasoning tokens are billable. `OmniAI::Chat::Usage#thinking_tokens` reports how many of a response's output tokens were internal reasoning:
+
+```ruby
+response = client.chat("What is 25 * 25?", thinking: true)
+
+response.usage.output_tokens   # => 1424 — billable output, reasoning included
+response.usage.thinking_tokens # => 840  — the reasoning subset of the above
+```
+
+`thinking_tokens` is always a **subset** of `output_tokens`, never an addition to it. Adding the two together double counts.
+
+It is `nil` when the provider reported no breakdown, which is deliberately distinct from `0` (the provider reported that no reasoning occurred). Each provider gem reads its own vocabulary:
+
+| Provider | Populated | Read from |
+|----------|-----------|-----------|
+| omniai-google >= 3.12 | yes | `thoughtsTokenCount` |
+| omniai-anthropic >= 3.6 | yes | `usage.output_tokens_details.thinking_tokens` |
+| omniai-openai >= 3.2 | yes | `usage.output_tokens_details.reasoning_tokens` (Responses API) |
+| omniai-mistral | no | no breakdown reported |
+
+Note also that `total_tokens` may exceed `input_tokens + output_tokens` — providers count buckets OmniAI does not model, such as cached input and tool-use prompts — and may be `nil` where a provider reports no total. The reported total is authoritative and is never recomputed from the parts.
+
 ### 🎤 Speech to Text
 
 Clients that support transcribe (e.g. OpenAI w/ "Whisper") convert recordings to text via the following calls:

--- a/lib/omniai/chat/response.rb
+++ b/lib/omniai/chat/response.rb
@@ -153,20 +153,30 @@ module OmniAI
       # Returns aggregated usage across all responses in the chain.
       # Walks the parent chain and sums all token counts.
       #
+      # `total_tokens` prefers each response's provider-reported total and only falls back to `input + output` for
+      # responses where the provider reported none. Summing the reported totals matters wherever a provider counts
+      # tokens that are neither input nor output — Google's `totalTokenCount` includes thinking tokens, so
+      # recomputing unconditionally would discard them.
+      #
+      # Known limitation: Anthropic reports no total at all, so its contribution is always the derived
+      # `input + output`, which excludes `cache_creation_input_tokens` and `cache_read_input_tokens`. An aggregate
+      # spanning Anthropic responses therefore understates cache-heavy conversations.
+      #
       # @return [Usage, nil]
       def total_usage
-        chain = response_chain
-        usages = chain.map(&:usage).compact
+        usages = response_chain.map(&:usage).compact
         return nil if usages.empty?
 
-        input_tokens = usages.sum { |u| u.input_tokens || 0 }
-        output_tokens = usages.sum { |u| u.output_tokens || 0 }
+        input_tokens = usages.sum { |usage| usage.input_tokens || 0 }
+        output_tokens = usages.sum { |usage| usage.output_tokens || 0 }
+        total_tokens = usages.sum do |usage|
+          usage.total_tokens || ((usage.input_tokens || 0) + (usage.output_tokens || 0))
+        end
 
-        Usage.new(
-          input_tokens:,
-          output_tokens:,
-          total_tokens: input_tokens + output_tokens
-        )
+        thinking = usages.filter_map(&:thinking_tokens)
+        thinking_tokens = thinking.sum unless thinking.empty?
+
+        Usage.new(input_tokens:, output_tokens:, total_tokens:, thinking_tokens:)
       end
     end
   end

--- a/lib/omniai/chat/usage.rb
+++ b/lib/omniai/chat/usage.rb
@@ -16,13 +16,13 @@ module OmniAI
     # Provider-specific vocabulary is read by that provider's own `:usage` deserializer, not here. This class reads
     # only its own keys and the flat OpenAI-compatible aliases the base client speaks.
     class Usage
-      # @return [Integer]
+      # @return [Integer, nil]
       attr_accessor :input_tokens
 
-      # @return [Integer]
+      # @return [Integer, nil]
       attr_accessor :output_tokens
 
-      # @return [Integer]
+      # @return [Integer, nil]
       attr_accessor :total_tokens
 
       # The subset of `output_tokens` a provider attributes to internal reasoning ("thinking"). `nil` when the
@@ -32,9 +32,9 @@ module OmniAI
       # @return [Integer, nil]
       attr_accessor :thinking_tokens
 
-      # @param input_tokens [Integer]
-      # @param output_tokens [Integer]
-      # @param total_tokens [Integer]
+      # @param input_tokens [Integer, nil]
+      # @param output_tokens [Integer, nil]
+      # @param total_tokens [Integer, nil]
       # @param thinking_tokens [Integer, nil] optional
       def initialize(input_tokens:, output_tokens:, total_tokens:, thinking_tokens: nil)
         @input_tokens = input_tokens

--- a/lib/omniai/chat/usage.rb
+++ b/lib/omniai/chat/usage.rb
@@ -13,18 +13,30 @@ module OmniAI
       # @return [Integer]
       attr_accessor :total_tokens
 
+      # The subset of `output_tokens` a provider attributes to internal reasoning ("thinking"). `nil` when the
+      # provider does not report a breakdown — which is distinct from `0`, meaning the provider reported that no
+      # reasoning occurred.
+      #
+      # @return [Integer, nil]
+      attr_accessor :thinking_tokens
+
       # @param input_tokens [Integer]
       # @param output_tokens [Integer]
       # @param total_tokens [Integer]
-      def initialize(input_tokens:, output_tokens:, total_tokens:)
+      # @param thinking_tokens [Integer, nil] optional
+      def initialize(input_tokens:, output_tokens:, total_tokens:, thinking_tokens: nil)
         @input_tokens = input_tokens
         @output_tokens = output_tokens
         @total_tokens = total_tokens
+        @thinking_tokens = thinking_tokens
       end
 
       # @return [String]
       def inspect
-        "#<#{self.class.name} input_tokens=#{input_tokens} output_tokens=#{output_tokens} total_tokens=#{total_tokens}>"
+        text = "#<#{self.class.name} input_tokens=#{input_tokens} output_tokens=#{output_tokens} " \
+          "total_tokens=#{total_tokens}"
+        text += " thinking_tokens=#{thinking_tokens}" unless thinking_tokens.nil?
+        "#{text}>"
       end
 
       # @param data [Hash]
@@ -38,9 +50,24 @@ module OmniAI
         input_tokens = data["input_tokens"] || data["prompt_tokens"]
         output_tokens = data["output_tokens"] || data["completion_tokens"]
         total_tokens = data["total_tokens"]
+        thinking_tokens = deserialize_thinking_tokens(data)
 
-        new(input_tokens:, output_tokens:, total_tokens:)
+        new(input_tokens:, output_tokens:, total_tokens:, thinking_tokens:)
       end
+
+      # Providers that already fold reasoning into `output_tokens` report it separately as a breakdown. Anthropic
+      # uses `output_tokens_details.thinking_tokens`; OpenAI uses `completion_tokens_details.reasoning_tokens`. In
+      # both cases the value is a subset of the output tokens, never an addition to them.
+      #
+      # @param data [Hash]
+      #
+      # @return [Integer, nil]
+      def self.deserialize_thinking_tokens(data)
+        data["thinking_tokens"] ||
+          data["output_tokens_details"]&.fetch("thinking_tokens", nil) ||
+          data["completion_tokens_details"]&.fetch("reasoning_tokens", nil)
+      end
+      private_class_method :deserialize_thinking_tokens
 
       # @param context [OmniAI::Context] optional
       #
@@ -53,7 +80,7 @@ module OmniAI
           input_tokens:,
           output_tokens:,
           total_tokens:,
-        }
+        }.tap { |data| data[:thinking_tokens] = thinking_tokens unless thinking_tokens.nil? }
       end
     end
   end

--- a/lib/omniai/chat/usage.rb
+++ b/lib/omniai/chat/usage.rb
@@ -3,6 +3,18 @@
 module OmniAI
   class Chat
     # The usage of a chat in terms of tokens (input / output / total).
+    #
+    # Two invariants hold across every provider:
+    #
+    # - `thinking_tokens` is a *subset* of `output_tokens`, never an addition to it. Providers either fold reasoning
+    #   into their output count already (reporting the breakdown separately) or report it separately and have it
+    #   added in by their own serializer. Adding `thinking_tokens` to `output_tokens` double counts.
+    # - `total_tokens` may exceed `input_tokens + output_tokens`. Providers count buckets this class does not model
+    #   — cached input, tool-use prompts — so the reported total is authoritative and is never recomputed from the
+    #   parts. It may also be `nil`: some providers report no total at all.
+    #
+    # Provider-specific vocabulary is read by that provider's own `:usage` deserializer, not here. This class reads
+    # only its own keys and the flat OpenAI-compatible aliases the base client speaks.
     class Usage
       # @return [Integer]
       attr_accessor :input_tokens
@@ -50,24 +62,10 @@ module OmniAI
         input_tokens = data["input_tokens"] || data["prompt_tokens"]
         output_tokens = data["output_tokens"] || data["completion_tokens"]
         total_tokens = data["total_tokens"]
-        thinking_tokens = deserialize_thinking_tokens(data)
+        thinking_tokens = data["thinking_tokens"]
 
         new(input_tokens:, output_tokens:, total_tokens:, thinking_tokens:)
       end
-
-      # Providers that already fold reasoning into `output_tokens` report it separately as a breakdown. Anthropic
-      # uses `output_tokens_details.thinking_tokens`; OpenAI uses `completion_tokens_details.reasoning_tokens`. In
-      # both cases the value is a subset of the output tokens, never an addition to them.
-      #
-      # @param data [Hash]
-      #
-      # @return [Integer, nil]
-      def self.deserialize_thinking_tokens(data)
-        data["thinking_tokens"] ||
-          data["output_tokens_details"]&.fetch("thinking_tokens", nil) ||
-          data["completion_tokens_details"]&.fetch("reasoning_tokens", nil)
-      end
-      private_class_method :deserialize_thinking_tokens
 
       # @param context [OmniAI::Context] optional
       #

--- a/lib/omniai/version.rb
+++ b/lib/omniai/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniAI
-  VERSION = "3.7.1"
+  VERSION = "3.8.0"
 end

--- a/spec/factories/chat/usage.rb
+++ b/spec/factories/chat/usage.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     input_tokens { 2 }
     output_tokens { 3 }
     total_tokens { input_tokens + output_tokens }
+    thinking_tokens { nil }
   end
 end

--- a/spec/omniai/chat/response_spec.rb
+++ b/spec/omniai/chat/response_spec.rb
@@ -208,8 +208,40 @@ RSpec.describe OmniAI::Chat::Response do
         expect(response.total_usage.output_tokens).to eq(153)
       end
 
-      it "calculates total_tokens from input + output" do
-        expect(response.total_usage.total_tokens).to eq(302 + 153)
+      it "sums the provider-reported totals" do
+        # grandparent(150) + parent(300) + self(5) = 455
+        expect(response.total_usage.total_tokens).to eq(455)
+      end
+    end
+
+    context "when a provider reports a total larger than input + output" do
+      # Google counts thinking tokens in `totalTokenCount` but not in `candidatesTokenCount`, so a reported total
+      # legitimately exceeds input + output. Recomputing unconditionally would discard the difference.
+      let(:usage) do
+        OmniAI::Chat::Usage.new(input_tokens: 53, output_tokens: 550, total_tokens: 1409, thinking_tokens: 806)
+      end
+
+      it "preserves the reported total rather than recomputing it" do
+        expect(response.total_usage.total_tokens).to eq(1409)
+      end
+
+      it "aggregates thinking_tokens" do
+        expect(response.total_usage.thinking_tokens).to eq(806)
+      end
+    end
+
+    context "when a provider reports no total" do
+      # Anthropic sends no `total_tokens` field at all.
+      let(:usage) { OmniAI::Chat::Usage.new(input_tokens: 10, output_tokens: 20, total_tokens: nil) }
+
+      it "falls back to input + output for that response" do
+        expect(response.total_usage.total_tokens).to eq(30)
+      end
+    end
+
+    context "when no response reports thinking tokens" do
+      it "leaves thinking_tokens nil rather than reporting zero" do
+        expect(response.total_usage.thinking_tokens).to be_nil
       end
     end
 

--- a/spec/omniai/chat/usage_spec.rb
+++ b/spec/omniai/chat/usage_spec.rb
@@ -15,8 +15,41 @@ RSpec.describe OmniAI::Chat::Usage do
     it { expect(usage.total_tokens).to eq(5) }
   end
 
+  describe "#thinking_tokens" do
+    context "when the provider reports no breakdown" do
+      it "is nil rather than zero" do
+        expect(usage.thinking_tokens).to be_nil
+      end
+    end
+
+    context "when the provider reports zero" do
+      subject(:usage) { build(:chat_usage, thinking_tokens: 0) }
+
+      it "is distinguishable from an absent breakdown" do
+        expect(usage.thinking_tokens).to eq(0)
+      end
+    end
+
+    context "when the provider reports a breakdown" do
+      subject(:usage) { build(:chat_usage, input_tokens: 2, output_tokens: 9, thinking_tokens: 6) }
+
+      it "is a subset of the output tokens, never an addition to them" do
+        expect(usage.thinking_tokens).to be <= usage.output_tokens
+      end
+    end
+  end
+
   describe "#inspect" do
     it { expect(usage.inspect).to eq("#<OmniAI::Chat::Usage input_tokens=2 output_tokens=3 total_tokens=5>") }
+
+    context "with thinking tokens" do
+      subject(:usage) { build(:chat_usage, input_tokens: 2, output_tokens: 9, total_tokens: 11, thinking_tokens: 6) }
+
+      it {
+        expect(usage.inspect)
+          .to eq("#<OmniAI::Chat::Usage input_tokens=2 output_tokens=9 total_tokens=11 thinking_tokens=6>")
+      }
+    end
   end
 
   describe ".deserialize" do
@@ -49,6 +82,46 @@ RSpec.describe OmniAI::Chat::Usage do
       it { expect(deserialize.input_tokens).to eq(2) }
       it { expect(deserialize.output_tokens).to eq(3) }
       it { expect(deserialize.total_tokens).to eq(5) }
+      it { expect(deserialize.thinking_tokens).to be_nil }
+    end
+
+    context "with an Anthropic-style breakdown" do
+      let(:context) { OmniAI::Context.build }
+      let(:data) do
+        {
+          "input_tokens" => 2,
+          "output_tokens" => 9,
+          "output_tokens_details" => { "thinking_tokens" => 6 },
+        }
+      end
+
+      it "reads thinking_tokens from the breakdown" do
+        expect(deserialize.thinking_tokens).to eq(6)
+      end
+
+      it "leaves output_tokens alone, because the provider already includes reasoning in it" do
+        expect(deserialize.output_tokens).to eq(9)
+      end
+    end
+
+    context "with an OpenAI-style breakdown" do
+      let(:context) { OmniAI::Context.build }
+      let(:data) do
+        {
+          "prompt_tokens" => 2,
+          "completion_tokens" => 9,
+          "total_tokens" => 11,
+          "completion_tokens_details" => { "reasoning_tokens" => 6 },
+        }
+      end
+
+      it "reads thinking_tokens from the breakdown" do
+        expect(deserialize.thinking_tokens).to eq(6)
+      end
+
+      it "leaves completion_tokens alone, because the provider already includes reasoning in it" do
+        expect(deserialize.output_tokens).to eq(9)
+      end
     end
   end
 
@@ -75,6 +148,17 @@ RSpec.describe OmniAI::Chat::Usage do
       let(:context) { OmniAI::Context.build }
 
       it { is_expected.to eq(input_tokens: 2, output_tokens: 3, total_tokens: 5) }
+    end
+
+    context "with thinking tokens" do
+      let(:usage) { build(:chat_usage, input_tokens: 2, output_tokens: 9, total_tokens: 11, thinking_tokens: 6) }
+      let(:context) { OmniAI::Context.build }
+
+      it { is_expected.to eq(input_tokens: 2, output_tokens: 9, total_tokens: 11, thinking_tokens: 6) }
+
+      it "round-trips" do
+        expect(described_class.deserialize(serialize.transform_keys(&:to_s)).thinking_tokens).to eq(6)
+      end
     end
   end
 end

--- a/spec/omniai/chat/usage_spec.rb
+++ b/spec/omniai/chat/usage_spec.rb
@@ -85,7 +85,18 @@ RSpec.describe OmniAI::Chat::Usage do
       it { expect(deserialize.thinking_tokens).to be_nil }
     end
 
-    context "with an Anthropic-style breakdown" do
+    context "with its own thinking_tokens key" do
+      let(:context) { OmniAI::Context.build }
+      let(:data) { { "input_tokens" => 2, "output_tokens" => 9, "thinking_tokens" => 6 } }
+
+      it "round-trips the field this class serializes" do
+        expect(deserialize.thinking_tokens).to eq(6)
+      end
+    end
+
+    context "with provider-specific breakdown vocabulary" do
+      # Base reads only its own key and the flat OpenAI-compatible aliases. Nested vendor shapes are read by that
+      # provider gem's own :usage deserializer, so base must not pick them up.
       let(:context) { OmniAI::Context.build }
       let(:data) do
         {
@@ -95,32 +106,8 @@ RSpec.describe OmniAI::Chat::Usage do
         }
       end
 
-      it "reads thinking_tokens from the breakdown" do
-        expect(deserialize.thinking_tokens).to eq(6)
-      end
-
-      it "leaves output_tokens alone, because the provider already includes reasoning in it" do
-        expect(deserialize.output_tokens).to eq(9)
-      end
-    end
-
-    context "with an OpenAI-style breakdown" do
-      let(:context) { OmniAI::Context.build }
-      let(:data) do
-        {
-          "prompt_tokens" => 2,
-          "completion_tokens" => 9,
-          "total_tokens" => 11,
-          "completion_tokens_details" => { "reasoning_tokens" => 6 },
-        }
-      end
-
-      it "reads thinking_tokens from the breakdown" do
-        expect(deserialize.thinking_tokens).to eq(6)
-      end
-
-      it "leaves completion_tokens alone, because the provider already includes reasoning in it" do
-        expect(deserialize.output_tokens).to eq(9)
+      it "does not read it" do
+        expect(deserialize.thinking_tokens).to be_nil
       end
     end
   end


### PR DESCRIPTION
## Why

There is no standardized way to read reasoning ("thinking") spend from a `Usage`. Providers report it three different ways, so any consumer computing cost has to reach into `response.data` and special-case the provider.

This surfaced from a live bug in `omniai-google` ([#87](https://github.com/ksylvest/omniai-google/pull/87)): Gemini bills reasoning as output but reports it separately, and the gem read only the answer count. Measured against live Vertex on `gemini-2.5-flash`, **59% of billable output was missing**. Thinking is on by default on Gemini 3.x flash, so that is the default path.

## What

**`Usage#thinking_tokens`** — the subset of `output_tokens` a provider attributes to internal reasoning.

The design rule is that it is always a **subset** of `output_tokens`, never an addition, so the field means the same thing everywhere. That is not invented here — it is Anthropic's own accounting, which describes the field as "how many of the billed output tokens were internal reasoning." Providers that already fold reasoning into output keep it and gain only the breakdown; Google's numbers are brought into line in its own gem.

Defaults to `nil` (no breakdown reported), deliberately distinct from `0` (provider reported no reasoning occurred) — same rule as `FinishReason`.

**This class reads only its own `thinking_tokens` key.** An earlier revision of this PR read `output_tokens_details.thinking_tokens` and `completion_tokens_details.reasoning_tokens` directly in base. That was wrong on two counts, and both are fixed:

- **Architecturally.** Base speaks the flat OpenAI-compatible dialect — `prompt_tokens`, `completion_tokens`, `choices`, `delta` — which many providers emit and which `omniai-mistral` depends on entirely, registering no serializers at all. A *nested* structure emitted by exactly one vendor is a different thing and belongs in that vendor's gem. Each provider now registers its own `:usage` deserializer, the mechanism `omniai-google` already used.
- **Factually.** The OpenAI path was dead code. `omniai-openai` targets the Responses API, whose usage object reports `output_tokens_details.reasoning_tokens`; `completion_tokens_details` is Chat Completions vocabulary from the previous generation and never reaches that gem. Fixed properly in [omniai-openai#217](https://github.com/ksylvest/omniai-openai/pull/217).

**`Response#total_usage` no longer discards provider-reported totals.** It recomputed `total_tokens` as `input + output` unconditionally, dropping any tokens a provider counts as neither — Google's `totalTokenCount` includes thinking, and also carries buckets like `toolUsePromptTokenCount`. It now sums each response's reported total, falling back to `input + output` only where a provider reported none.

Known limitation, documented rather than hidden: Anthropic sends no total, so its contribution is the derived `input + output`, which excludes `cache_creation_input_tokens` / `cache_read_input_tokens`.

**Invariants are documented on the class**, not only in the changelog: `thinking_tokens` is a subset of `output_tokens`; `total_tokens` may exceed `input + output` or be `nil`, because providers count buckets this class does not model.

## Provider coverage

`thinking_tokens` is populated only by provider gems that ship a `:usage` deserializer. README and CHANGELOG both carry this table so the field is not read as universal:

| Provider | Populated | Read from |
|---|---|---|
| omniai-google >= 3.12 | yes | `thoughtsTokenCount` |
| omniai-anthropic >= 3.6 | yes | `usage.output_tokens_details.thinking_tokens` |
| omniai-openai >= 3.2 | yes | `usage.output_tokens_details.reasoning_tokens` (Responses API) |
| omniai-mistral | no | no breakdown reported |

Against any other gem it is `nil` — the same value it held before this release, so nothing regresses. `nil` does not mean "no reasoning occurred".

## Compatibility

`thinking_tokens:` is a defaulted keyword, so existing constructor calls are unaffected. `#inspect` appends the field only when non-nil, leaving existing output byte-identical.

**Release ordering:** the three provider gems tighten their floor to `~> 3.8` and cannot pass CI until this is published. **This must ship first.**

## Verification

480 examples, 0 failures. RuboCop clean. Verified live against Vertex on both streaming and non-streaming paths — see [#87](https://github.com/ksylvest/omniai-google/pull/87) for measured numbers.

Four-gem release: this · [omniai-google#87](https://github.com/ksylvest/omniai-google/pull/87) · [omniai-anthropic#209](https://github.com/ksylvest/omniai-anthropic/pull/209) · [omniai-openai#217](https://github.com/ksylvest/omniai-openai/pull/217)
